### PR TITLE
Allow CRIS

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,9 +57,21 @@ func listModels() {
 
 	fmt.Fprintln(w, "\t\t")
 
-	// Print the models
+	// Filter and print the models that support ON_DEMAND inference
 	for _, model := range result.ModelSummaries {
-		fmt.Fprintf(w, "%s\t %s\t %s\n", aws.ToString(model.ProviderName), aws.ToString(model.ModelName), aws.ToString(model.ModelId))
+		// Check if ON_DEMAND is in the inferenceTypesSupported list
+		hasOnDemand := false
+		for _, inferenceType := range model.InferenceTypesSupported {
+			if inferenceType == "ON_DEMAND" {
+				hasOnDemand = true
+				break
+			}
+		}
+		
+		// Only print models that support ON_DEMAND
+		if hasOnDemand {
+			fmt.Fprintf(w, "%s\t %s\t %s\n", aws.ToString(model.ProviderName), aws.ToString(model.ModelName), aws.ToString(model.ModelId))
+		}
 	}
 
 	// Flush the writer


### PR DESCRIPTION
With addition of cross-region inference only models, ie Claude Sonnet 3.7, added two flags to the functionality for prompt methods.  
--inference-profile -p = directly allows calling a Bedrock cross-region inference profile
--skip-validation = disables the internal model ID validation check, allowing using the standard --model-id flag with an inference profile

Examples:
`chat-cli prompt --inference-profile us.anthropic.claude-3-7-sonnet-20250219-v1:0 "Tell me a joke about horses"`
`chat-cli prompt -p us.anthropic.claude-3-7-sonnet-20250219-v1:0 "Tell me a joke about horses"`
`chat-cli prompt --skip-validation -m us.anthropic.claude-3-7-sonnet-20250219-v1:0 "What is the capital of France?"`

Note: I did not modify the `chat-cli chat` method.