### PR TITLE
Add AI-DLC reverse-engineering documentation for chat-cli

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-08T00:00:00Z
-- **Current Stage**: INCEPTION - Reverse Engineering
+- **Current Stage**: INCEPTION - Requirements Analysis
 
 ## Workspace State
 - **Existing Code**: Yes
@@ -27,6 +27,6 @@
 
 ## Stage Progress
 - [x] Workspace Detection - Completed 2026-07-08
-- [x] Reverse Engineering - Completed 2026-07-08 (awaiting user review/approval)
-- [ ] Requirements Analysis
+- [x] Reverse Engineering - Completed 2026-07-08 (approved by user)
+- [ ] Requirements Analysis - In Progress
 - [ ] Workflow Planning

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -1,0 +1,32 @@
+# AI-DLC State Tracking
+
+## Project Information
+- **Project Type**: Brownfield
+- **Start Date**: 2026-07-08T00:00:00Z
+- **Current Stage**: INCEPTION - Reverse Engineering
+
+## Workspace State
+- **Existing Code**: Yes
+- **Programming Languages**: Go (26 .go files)
+- **Build System**: Go modules (go.mod), Makefile, GoReleaser
+- **Project Structure**: Monolith CLI (Cobra command layers: cmd/, config/, db/, repository/, factory/, utils/)
+- **Reverse Engineering Needed**: Yes
+- **Workspace Root**: /home/user/chat-cli
+
+## Code Location Rules
+- **Application Code**: Workspace root (NEVER in aidlc-docs/)
+- **Documentation**: aidlc-docs/ only
+- **Structure patterns**: See code-generation.md Critical Rules
+
+## Extension Configuration
+(none loaded yet - no extensions opted into)
+
+## Reverse Engineering Status
+- [x] Reverse Engineering - Completed on 2026-07-08T00:00:00Z
+- **Artifacts Location**: aidlc-docs/inception/reverse-engineering/
+
+## Stage Progress
+- [x] Workspace Detection - Completed 2026-07-08
+- [x] Reverse Engineering - Completed 2026-07-08 (awaiting user review/approval)
+- [ ] Requirements Analysis
+- [ ] Workflow Planning

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -3,7 +3,7 @@
 ## Project Information
 - **Project Type**: Brownfield
 - **Start Date**: 2026-07-08T00:00:00Z
-- **Current Stage**: INCEPTION - Requirements Analysis
+- **Current Stage**: INCEPTION - Requirements Analysis (PAUSED by user)
 
 ## Workspace State
 - **Existing Code**: Yes
@@ -28,5 +28,13 @@
 ## Stage Progress
 - [x] Workspace Detection - Completed 2026-07-08
 - [x] Reverse Engineering - Completed 2026-07-08 (approved by user)
-- [ ] Requirements Analysis - In Progress
+- [ ] Requirements Analysis - PAUSED 2026-07-08 (clarifying questions issued, not yet answered)
 - [ ] Workflow Planning
+
+## Resume Instructions
+Session paused at the user's request before answering the clarifying
+questions below. To resume:
+1. Read `aidlc-docs/inception/reverse-engineering/` artifacts (already generated - business overview,
+   architecture, code structure, API docs, component inventory, tech stack, dependencies, code quality)
+2. Read and answer `aidlc-docs/inception/requirements/requirement-verification-questions.md`
+3. Continue Requirements Analysis Step 7 (generate requirements.md) once answers are provided

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -31,3 +31,11 @@
 **Context**: Requirements Analysis stage, INCEPTION phase
 
 ---
+
+## Session Paused
+**Timestamp**: 2026-07-08T00:10:00Z
+**User Input**: "Let's just stop here so I can pick this up with a new direction in the future"
+**AI Response**: "Marked Requirements Analysis as PAUSED in aidlc-state.md with resume instructions. Reverse-engineering artifacts remain approved and available under aidlc-docs/inception/reverse-engineering/. The clarifying-questions file (requirement-verification-questions.md) is left unanswered for a future session to pick up once a direction is chosen."
+**Context**: Requirements Analysis stage, INCEPTION phase - workflow paused, not abandoned
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -15,3 +15,19 @@
 **Context**: Reverse Engineering stage, INCEPTION phase
 
 ---
+
+## Reverse Engineering Approval
+**Timestamp**: 2026-07-08T00:05:00Z
+**User Input**: "Approve and continue"
+**AI Response**: "Approval recorded. Proceeding to Requirements Analysis."
+**Context**: Reverse Engineering stage approval, INCEPTION phase
+
+---
+
+## Requirements Analysis - Clarifying Questions
+**Timestamp**: 2026-07-08T00:06:00Z
+**User Input**: (n/a - AI-initiated per Requirements Analysis Step 6, gate before requirements.md can be generated)
+**AI Response**: "Original request ('document and understand... in preparation to continue new development ideas') does not specify a concrete feature/fix. Created aidlc-docs/inception/requirements/requirement-verification-questions.md with 4 questions covering: work type, specificity of idea, scope for this round, and constraints. Presenting to user and waiting (GATE) before generating requirements.md."
+**Context**: Requirements Analysis stage, INCEPTION phase
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1,0 +1,17 @@
+# AI-DLC Audit Log
+
+## Workspace Detection
+**Timestamp**: 2026-07-08T00:00:00Z
+**User Input**: "Using AI-DLC I want to document and understand what this project is all about in preparation to continue new development ideas"
+**AI Response**: "Installed AI-DLC rule files (awslabs/aidlc-workflows v1.0.1) into .aidlc/aidlc-rules/ (gitignored per CLAUDE.md setup). Detected brownfield Go project (chat-cli), no existing aidlc-state.md or reverse-engineering artifacts found. Proceeding to Reverse Engineering."
+**Context**: Workspace Detection stage, INCEPTION phase
+
+---
+
+## Reverse Engineering
+**Timestamp**: 2026-07-08T00:00:00Z
+**User Input**: (none - automatic continuation per workflow, no approval required between Workspace Detection and Reverse Engineering)
+**AI Response**: "Analyzed all 26 Go source files across cmd/, config/, db/, db/sqlite/, factory/, repository/, utils/. Generated 8 artifacts in aidlc-docs/inception/reverse-engineering/: business-overview.md, architecture.md, code-structure.md, api-documentation.md, component-inventory.md, technology-stack.md, dependencies.md, code-quality-assessment.md, plus reverse-engineering-timestamp.md. Identified 7 technical debt items including a region-flag bug in modelsList.go, duplicated model-validation logic across chat/prompt/image commands, an unimplemented Repository[T] interface, and a stray .goreleaser.yaml.backup file. Presenting completion message and awaiting user approval before proceeding to Requirements Analysis."
+**Context**: Reverse Engineering stage, INCEPTION phase
+
+---

--- a/aidlc-docs/inception/requirements/requirement-verification-questions.md
+++ b/aidlc-docs/inception/requirements/requirement-verification-questions.md
@@ -1,0 +1,51 @@
+# Requirements Clarification Questions
+
+Your original request was to "document and understand what this project is all about in preparation to continue new development ideas." Reverse Engineering is now complete and approved. Before I can produce a requirements document, I need to know what you actually want to build or change next — please answer the questions below.
+
+## Question 1
+What type of work are you looking to do next?
+
+A) Add a new user-facing feature or capability to chat-cli
+
+B) Fix technical debt / bugs identified during the reverse-engineering review (region flag bug, duplicated model-validation logic, unimplemented `Repository[T]` methods, stray backup file, unmaintained `go.uuid` dependency, etc.)
+
+C) Non-functional improvement (raise test coverage, add CI, refactor without behavior change)
+
+D) Not sure yet — I'd like suggestions based on what the reverse-engineering review found
+
+E) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 2
+Do you already have a specific idea in mind?
+
+A) Yes — I'll describe it in the Other field below
+
+B) No — please propose a shortlist of candidate ideas based on the codebase review, and I'll pick from those
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 3
+How much should we take on in this round?
+
+A) One focused feature or fix
+
+B) A small bundle of related quick wins (e.g., 2-3 of the technical debt items together)
+
+C) A larger initiative spanning multiple components
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 4
+Are there any constraints I should design around (backward compatibility with existing `chat-cli` flags/config, specific AWS regions, timeline, must avoid new dependencies, etc.)? If none, say "none."
+
+A) None — no special constraints
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:

--- a/aidlc-docs/inception/reverse-engineering/api-documentation.md
+++ b/aidlc-docs/inception/reverse-engineering/api-documentation.md
@@ -1,0 +1,106 @@
+# API Documentation
+
+Chat-CLI exposes no network-facing REST/HTTP API — it is a CLI. This document treats the **CLI command surface** as the "external API" (what end users/scripts invoke) and documents the **internal package APIs** used across layers.
+
+## CLI Commands (External API)
+
+### `chat-cli` (root, no subcommand)
+- **Purpose**: Start (or resume, with `--chat-id`) an interactive streaming chat session. Equivalent to `chat-cli chat`.
+- **Persistent Flags** (also inherited by all subcommands): `-r, --region` (default `us-east-1`), `-m, --model-id` (default `anthropic.claude-3-5-sonnet-20240620-v1:0`), `--custom-arn`, `--chat-id`, `--temperature` (default `1.0`), `--topP` (default `0.999`), `--max-tokens` (default `500`).
+- **Behavior**: Validates the model supports text output + streaming (unless `--custom-arn` is set, which skips validation), opens the local SQLite DB, replays prior messages if `--chat-id` given, then loops reading user input and streaming Bedrock responses until `quit`/`/quit`/Ctrl-C.
+
+### `chat-cli chat`
+- **Purpose**: Alias/explicit form of the root command's default behavior.
+- **Flags**: Same as root (inherited persistent flags).
+
+### `chat-cli chat list`
+- **Purpose**: Print the 10 most recent chat sessions.
+- **Output**: Tab-formatted table: `Created Date | Chat ID | Title` (title = first 40 chars of the stored message).
+
+### `chat-cli prompt "<text>"`
+- **Purpose**: Send a single one-shot prompt and print the response.
+- **Args**: `args[0]` = prompt text (required, `cobra.MinimumNArgs(1)`); stdin (if piped) is appended as a `<document>` block.
+- **Flags**: `-m, --model-id` (default `anthropic.claude-3-5-sonnet-20240620-v1:0`), `--custom-arn`, `-i, --image` (path to PNG/JPG < 5MB), `--no-stream` (return full response instead of streaming), `--temperature`, `--topP`, `--max-tokens`.
+- **Behavior**: Validates model supports text (and image input, if `--image` set; and streaming, unless `--no-stream`) via `bedrock.GetFoundationModel`, then calls `bedrockruntime.Converse` (no-stream) or `ConverseStream` (default).
+
+### `chat-cli image "<prompt>"`
+- **Purpose**: Generate an image and save it to disk.
+- **Args**: `args[0]` = prompt text (required); stdin document supported like `prompt`.
+- **Flags**: `-m, --model-id` (default `amazon.nova-canvas-v1:0`), `--scale` (default `10`), `--steps` (default `10`), `--seed` (default `0`), `-f, --filename` (default: `<unix-timestamp>.jpg`).
+- **Behavior**: Validates model supports `IMAGE` output; builds a provider-specific request body (Stability AI or Amazon Titan schema, chosen by `model.ModelDetails.ProviderName`); calls `bedrockruntime.InvokeModel`; decodes and writes the base64 image to disk.
+
+### `chat-cli models list`
+- **Purpose**: List all foundation models available in the configured region (hardcoded to `us-east-1` inside `listModels()`, independent of the `--region` flag — see code-quality-assessment.md).
+- **Output**: Tab-formatted table: `Provider | Name | Model ID`.
+
+### `chat-cli config set <key> <value>`
+- **Purpose**: Persist a default config value. Supported keys: `model-id`, `custom-arn`.
+
+### `chat-cli config unset <key>`
+- **Purpose**: Remove a persisted config value. Supported keys: `model-id`, `custom-arn`.
+
+### `chat-cli config list`
+- **Purpose**: Print all currently set supported config values (or "No configuration values set").
+
+### `chat-cli version`
+- **Purpose**: Print CLI version (currently hardcoded `v0.5.3`) and `GOOS/GOARCH`.
+
+## Internal APIs
+
+### `config.FileManager` (`config/config.go`)
+- **Methods**:
+  - `NewFileManager(appName string) (*FileManager, error)` — constructs and initializes OS-specific paths.
+  - `(fm *FileManager) InitializeViper() error` — configures and loads/creates the Viper-backed YAML config.
+  - `(fm *FileManager) GetDBPath() string` — full path to the SQLite file.
+  - `(fm *FileManager) GetDBDriver() string` — configured DB driver (`db_driver`, default `sqlite`).
+  - `(fm *FileManager) GetConfigValue(key string, flagValue, defaultValue interface{}) interface{}` — precedence resolver (flag → config file → default); supports `string`, `int32`, `float32` flag types.
+- **Parameters/Return Types**: See above; `GetConfigValue` returns `interface{}` and callers type-assert (e.g. `.(string)`).
+
+### `db.Database` (`db/db.go`)
+- **Methods**: `GetDB() *sql.DB`, `Connect() error`, `Close() error`, `Migrate() error`.
+- **Implementations**: `sqlite.SQLiteDB`.
+
+### `db.Migration` (`db/migrations.go`)
+- **Methods**: `MigrateUp() error`, `MigrateDown() error`.
+- **Implementations**: `sqlite.SQLiteMigration`.
+
+### `factory.CreateDatabase` (`factory/database.go`)
+- **Signature**: `CreateDatabase(config *db.Config) (db.Database, error)`.
+- **Behavior**: Dispatches on `config.Driver`; only `"sqlite"` implemented today; unknown drivers return an error.
+
+### `repository.Repository[T]` (`repository/base.go`)
+- **Methods** (generic interface, not fully implemented by `ChatRepository`): `Create(entity *T) error`, `GetByID(id int) (*T, error)`, `Update(entity *T) error`, `Delete(id int) error`, `List() ([]T, error)`.
+
+### `repository.ChatRepository` (`repository/chat.go`)
+- **Methods**:
+  - `NewChatRepository(db db.Database) *ChatRepository`
+  - `(r *ChatRepository) Create(chat *Chat) error` — inserts a row; note `RETURNING id` in a raw SQL string with modernc.org/sqlite (see code-quality-assessment.md for a caveat).
+  - `(r *ChatRepository) List() ([]Chat, error)` — 10 most recent chats, grouped by `chat_id`, newest first.
+  - `(r *ChatRepository) GetMessages(chatId string) ([]Chat, error)` — full ordered transcript for one chat.
+- **Parameters**: `Chat{ID int, ChatId string, Persona string, Message string, Created string}`.
+
+### `utils` package (`utils/utils.go`, `utils/bubbleinput.go`)
+- **Methods**:
+  - `ProcessStreamingOutput(output *bedrockruntime.ConverseStreamOutput, handler StreamingOutputHandler) (types.Message, error)` — drains the Bedrock stream, invoking `handler(ctx, textDelta)` per chunk, returns the assembled `types.Message`.
+  - `ReadImage(filename string) (data []byte, imageType string, err error)` — path-traversal-safe local image read; supports jpg/jpeg/png/gif/webp.
+  - `DecodeImage(base64Image string) ([]byte, error)` — base64 decode.
+  - `StringPrompt(label string) string` — TTY-aware input: uses `BubbleInput()` interactively, falls back to buffered stdin read otherwise.
+  - `LoadDocument() (string, error)` — reads piped stdin (if not a TTY) and wraps it in `<document>...</document>`.
+  - `BubbleInput() (string, bool)` — runs the BubbleTea `InputField` program and returns the submitted line (`/quit` normalized to `quit\n`).
+
+## Data Models
+
+### `repository.Chat` (`repository/chat.go`)
+- **Fields**: `ID int`, `ChatId string`, `Persona string` ("User" or "Assistant"), `Message string`, `Created string` (populated from `created_at` on read).
+- **Relationships**: Many `Chat` rows share one `ChatId` (a conversation); no foreign keys — SQLite `chats` table is flat.
+- **Validation**: None at the Go struct level; all fields are `NOT NULL` at the SQL schema level (`db/sqlite/migrations.go`).
+
+### `db.Config` (`db/db.go`)
+- **Fields**: `Port int`, `Driver string`, `Host string`, `Name string`, `Username string`, `Password string`.
+- **Relationships**: Passed to `factory.CreateDatabase`; only `Driver` and `Name` are actually used by the SQLite implementation today — `Port`/`Host`/`Username`/`Password` are unused placeholders for a future networked backend (e.g. Postgres).
+- **Validation**: None.
+
+### SQL Schema — `chats` table (`db/sqlite/migrations.go`)
+- **Fields**: `id INTEGER PRIMARY KEY AUTOINCREMENT`, `chat_id TEXT NOT NULL`, `persona TEXT NOT NULL`, `message TEXT NOT NULL`, `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`, `updated_at DATETIME DEFAULT CURRENT_TIMESTAMP`.
+- **Relationships**: `chat_id` groups rows into conversations (no FK constraint).
+- **Validation**: `NOT NULL` on `chat_id`/`persona`/`message`; trigger `chats_updated_at` keeps `updated_at` current on row update.

--- a/aidlc-docs/inception/reverse-engineering/architecture.md
+++ b/aidlc-docs/inception/reverse-engineering/architecture.md
@@ -1,0 +1,172 @@
+# System Architecture
+
+## System Overview
+
+Chat-CLI is a single-binary Go CLI application (no server, no separate backend). It follows a layered architecture: a Cobra-based CLI layer dispatches to AWS Bedrock directly and to a small local persistence layer. There is exactly one deployable artifact (`chat-cli`), distributed as pre-built binaries (GoReleaser), via Homebrew, or built from source with `make`.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph CLI_LAYER["CLI Layer (cmd/)"]
+        Root["root.go<br/>rootCmd"]
+        Chat["chat.go<br/>chatCmd"]
+        ChatList["chatList.go<br/>chat list"]
+        Prompt["prompt.go<br/>promptCmd"]
+        Image["image.go<br/>imageCmd"]
+        Models["models.go / modelsList.go"]
+        Config["config.go<br/>configCmd set/unset/list"]
+        Version["version.go"]
+    end
+
+    subgraph SUPPORT["Support Layers"]
+        ConfigPkg["config/<br/>FileManager (Viper)"]
+        Utils["utils/<br/>streaming, image io, prompt input"]
+    end
+
+    subgraph PERSISTENCE["Persistence Layer"]
+        Factory["factory/<br/>CreateDatabase"]
+        DBIface["db/<br/>Database + Migration interfaces"]
+        SQLiteImpl["db/sqlite/<br/>SQLiteDB + migrations"]
+        RepoBase["repository/base.go<br/>Repository[T]"]
+        RepoChat["repository/chat.go<br/>ChatRepository"]
+    end
+
+    subgraph EXTERNAL["External Systems"]
+        Bedrock[("Amazon Bedrock<br/>bedrock + bedrockruntime APIs")]
+        SQLiteFile[("SQLite file<br/>~/.local/share/chat-cli/data.db")]
+        YamlFile[("config.yaml<br/>~/.config/chat-cli/config.yaml")]
+    end
+
+    Root --> Chat
+    Chat --> ConfigPkg
+    Chat --> Factory
+    Chat --> RepoChat
+    Chat --> Utils
+    Chat --> Bedrock
+
+    ChatList --> ConfigPkg
+    ChatList --> Factory
+    ChatList --> RepoChat
+
+    Prompt --> ConfigPkg
+    Prompt --> Utils
+    Prompt --> Bedrock
+
+    Image --> Utils
+    Image --> Bedrock
+
+    Models --> Bedrock
+    Config --> ConfigPkg
+
+    Factory --> DBIface
+    Factory --> SQLiteImpl
+    RepoChat --> RepoBase
+    RepoBase --> DBIface
+    SQLiteImpl --> SQLiteFile
+    ConfigPkg --> YamlFile
+```
+
+### Text Alternative
+```
+CLI Layer (cmd/): root -> chat, chat list, prompt, image, models/models list,
+config set/unset/list, version
+
+chat, chat list, prompt, config all depend on config/FileManager (Viper)
+chat, chat list depend on factory/CreateDatabase -> db/Database interface
+  -> db/sqlite implementation -> repository/ChatRepository -> SQLite file
+chat, prompt, image depend on utils/ (streaming output, image IO)
+chat, prompt, image, models all call Amazon Bedrock (bedrock + bedrockruntime APIs)
+```
+
+## Component Descriptions
+
+### cmd (CLI Layer)
+- **Purpose**: Entry point for every user interaction; defines all Cobra commands/flags.
+- **Responsibilities**: Argument/flag parsing, AWS Bedrock client construction and calls, orchestration of config + persistence layers, all user-facing output formatting.
+- **Dependencies**: `config`, `db`, `repository`, `factory`, `utils`, AWS SDK v2 (`bedrock`, `bedrockruntime`), Cobra.
+- **Type**: Application
+
+### config
+- **Purpose**: Resolve OS-specific config/data paths and manage a single Viper-backed YAML config file.
+- **Responsibilities**: Path resolution (Windows/macOS/Linux/XDG), config file bootstrap, flag→config→default precedence helper (`GetConfigValue`).
+- **Dependencies**: Viper, standard library `os`/`path/filepath`/`runtime`.
+- **Type**: Application (shared library within the monolith)
+
+### db
+- **Purpose**: Define storage-agnostic contracts so the rest of the app never depends on a concrete database.
+- **Responsibilities**: `Database` interface (`GetDB`, `Connect`, `Close`, `Migrate`), `Migration` interface, shared `Config` struct.
+- **Dependencies**: `database/sql` only.
+- **Type**: Application (abstraction layer)
+
+### db/sqlite
+- **Purpose**: Concrete SQLite implementation of the `db.Database`/`db.Migration` interfaces.
+- **Responsibilities**: Open a `database/sql` connection via the pure-Go `modernc.org/sqlite` driver; create/upgrade the `chats` table and its `updated_at` trigger.
+- **Dependencies**: `modernc.org/sqlite`, `db` package.
+- **Type**: Application (persistence implementation)
+
+### factory
+- **Purpose**: Select the concrete `db.Database` implementation at runtime based on configured driver.
+- **Responsibilities**: `CreateDatabase(config) (db.Database, error)` — currently only `"sqlite"` is wired up; a `"postgres"` branch is stubbed out in a comment for future use.
+- **Dependencies**: `db`, `db/sqlite`.
+- **Type**: Application (factory pattern)
+
+### repository
+- **Purpose**: Encapsulate SQL for chat persistence behind a generic repository interface.
+- **Responsibilities**: `Repository[T]` generic interface (Create/GetByID/Update/Delete/List — only partially implemented for Chat); `ChatRepository` with `Create`, `List` (10 most recent, grouped by chat_id), `GetMessages` (full transcript for a chat_id).
+- **Dependencies**: `db`.
+- **Type**: Application (repository pattern)
+
+### utils
+- **Purpose**: Cross-cutting helpers not tied to any one command.
+- **Responsibilities**: `ProcessStreamingOutput` (drains a Bedrock `ConverseStream` event channel into text + a `types.Message`), `ReadImage`/`DecodeImage` (image file IO + base64), `LoadDocument` (stdin piping), `StringPrompt`/`BubbleInput` (interactive terminal input widget built on `charmbracelet/bubbletea`).
+- **Dependencies**: AWS SDK v2 bedrockruntime types, `charmbracelet/bubbles`, `charmbracelet/bubbletea`, `charmbracelet/lipgloss`, `golang.org/x/term`, `mattn/go-isatty`.
+- **Type**: Application (shared utility library)
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (terminal)
+    participant C as chat.go (chatCmd)
+    participant Cfg as config.FileManager
+    participant DB as factory + repository
+    participant B as Amazon Bedrock
+
+    U->>C: chat-cli (no args)
+    C->>Cfg: NewFileManager + InitializeViper
+    C->>DB: CreateDatabase + Migrate
+    C->>DB: chatRepo.GetMessages(chatId) [if resuming]
+    loop each turn
+        U->>C: type message (BubbleInput)
+        C->>DB: chatRepo.Create(userMsg)
+        C->>B: ConverseStream(messages)
+        B-->>C: streamed text deltas
+        C-->>U: print deltas as they arrive
+        C->>DB: chatRepo.Create(assistantMsg)
+    end
+```
+
+### Text Alternative
+```
+1. User runs `chat-cli` (root delegates to chat command)
+2. chat.go loads config (FileManager/Viper) and opens the SQLite DB (factory + Migrate)
+3. If --chat-id is set, prior messages are loaded via ChatRepository.GetMessages and replayed
+4. Loop: user types a message (BubbleInput) -> saved to DB -> sent to Bedrock ConverseStream
+   -> streamed response printed live -> full response saved to DB -> repeat
+5. "quit" or "/quit" or Ctrl+C exits the loop
+```
+
+## Integration Points
+
+- **External APIs**:
+  - Amazon Bedrock Control Plane (`bedrock.GetFoundationModel`, `bedrock.ListFoundationModels`) — model discovery and capability checks (text/image/streaming support).
+  - Amazon Bedrock Runtime (`bedrockruntime.Converse`, `ConverseStream`, `InvokeModel`) — actual inference calls for chat, prompt, and image generation.
+- **Databases**: Local SQLite file (`data.db` in the OS data directory) — sole persistence store, holds the `chats` table (all conversation history).
+- **Third-party Services**: None beyond AWS (Bedrock). No telemetry, analytics, or other network calls found in the codebase.
+
+## Infrastructure Components
+
+- **CDK Stacks**: None — this is a client application, not infrastructure-as-code.
+- **Deployment Model**: Distributed as cross-platform binaries via GoReleaser (`.goreleaser.yaml`) and a Homebrew tap (`chat-cli/chat-cli`); users run it locally against their own AWS credentials/region.
+- **Networking**: No inbound networking. Outbound HTTPS calls only, to AWS Bedrock endpoints in the configured region (default `us-east-1`), authenticated via standard AWS SDK credential resolution (AWS CLI config/env/IAM role).

--- a/aidlc-docs/inception/reverse-engineering/business-overview.md
+++ b/aidlc-docs/inception/reverse-engineering/business-overview.md
@@ -1,0 +1,70 @@
+# Business Overview
+
+## Business Context Diagram
+
+```mermaid
+flowchart LR
+    User["Terminal User"]
+    CLI["chat-cli"]
+    Bedrock["Amazon Bedrock<br/>Foundation Models"]
+    AWSAuth["AWS Credentials<br/>(AWS CLI config)"]
+    LocalDB["Local SQLite DB<br/>(chat history)"]
+    LocalCfg["Local YAML Config<br/>(model defaults)"]
+
+    User -->|"runs commands"| CLI
+    CLI -->|"Converse / ConverseStream / InvokeModel"| Bedrock
+    CLI -->|"loads credentials via"| AWSAuth
+    CLI -->|"reads / writes"| LocalDB
+    CLI -->|"reads / writes"| LocalCfg
+    Bedrock -->|"streamed or full text / image response"| CLI
+    CLI -->|"prints response"| User
+```
+
+### Text Alternative
+```
+Terminal User --runs commands--> chat-cli
+chat-cli --Converse/ConverseStream/InvokeModel--> Amazon Bedrock
+chat-cli --loads credentials--> AWS Credentials (AWS CLI config)
+chat-cli --reads/writes--> Local SQLite DB (chat history)
+chat-cli --reads/writes--> Local YAML Config (model defaults)
+Amazon Bedrock --response--> chat-cli --prints--> Terminal User
+```
+
+## Business Description
+
+- **Business Description**: Chat-CLI is a terminal-based client that gives developers a fast, scriptable way to talk to Amazon Bedrock foundation models (Anthropic Claude and others) without leaving the command line. It covers three core use cases: one-shot prompting (for scripting/piping), persistent interactive chat (for conversational work), and image generation (for models that support it). It intentionally has no server component — every invocation talks directly to Bedrock using the user's own AWS credentials, and all state (chat history, config defaults) is stored locally on the user's machine.
+
+- **Business Transactions**:
+  - **Send One-Shot Prompt** (`chat-cli prompt "<text>"`) — send a single message to a model and print the response (streamed or full), optionally with an attached image or piped-in document content.
+  - **Start/Resume Interactive Chat** (`chat-cli` or `chat-cli --chat-id <id>`) — open a persistent, streaming conversation loop; every user/assistant turn is saved to SQLite and can be replayed by chat-id.
+  - **List Recent Chats** (`chat-cli chat list`) — show the 10 most recent chat sessions (id, timestamp, first message) so the user can find a chat-id to resume.
+  - **Generate Image** (`chat-cli image "<prompt>"`) — send a prompt to an image-generation model (Stability AI or Amazon Titan family) and write the resulting image to disk.
+  - **List Available Models** (`chat-cli models list`) — query Bedrock for all foundation models available in the configured region.
+  - **Manage Configuration** (`chat-cli config set|unset|list`) — persist default `model-id` / `custom-arn` values so they don't need to be passed as flags every time.
+  - **Print Version** (`chat-cli version`) — report the installed CLI version and platform.
+
+- **Business Dictionary**:
+  - **Model ID**: Bedrock's identifier for a foundation model (e.g. `anthropic.claude-3-5-sonnet-20240620-v1:0`).
+  - **Custom ARN**: An Amazon Resource Name pointing at a Bedrock Marketplace model or a cross-region inference profile; when set, it overrides `model-id`.
+  - **Chat ID**: A UUID that groups a sequence of user/assistant messages into one conversation, used as the SQLite `chat_id` and as the Bedrock `RequestMetadata` correlation key.
+  - **Persona**: Role label ("User" or "Assistant") stored per chat message row.
+  - **Streaming**: Bedrock's `ConverseStream` API, which returns model output incrementally as it's generated (used by `chat` always, and by `prompt` unless `--no-stream` is passed).
+  - **Document**: Content piped into `prompt`/`image` via stdin, auto-wrapped in `<document></document>` tags and appended to the prompt text (a convention Claude models respond well to).
+
+## Component Level Business Descriptions
+
+### cmd (CLI commands)
+- **Purpose**: The user-facing surface of the product — parses flags/args and orchestrates AWS Bedrock calls, config loading, and database access for every business transaction listed above.
+- **Responsibilities**: Command definitions (`root`, `chat`, `chat list`, `prompt`, `image`, `models`, `models list`, `config set/unset/list`, `version`); flag precedence resolution (flag → config → default); model capability validation (text/image/streaming) before calling Bedrock.
+
+### config (Configuration Layer)
+- **Purpose**: Give the CLI a persistent, OS-appropriate place to remember user preferences (default model, custom ARN, DB location) across invocations.
+- **Responsibilities**: Resolve OS-specific config/data directories (XDG on Linux, `Library/Application Support` on macOS, `%APPDATA%` on Windows); initialize Viper; implement the flag → config → default precedence rule.
+
+### db / repository / factory (Persistence Layer)
+- **Purpose**: Durably store chat history so conversations can be resumed and browsed later.
+- **Responsibilities**: Define a database-agnostic `Database` interface and `Repository[T]` pattern; provide a SQLite implementation with migrations; let a factory pick the concrete driver from config, keeping `cmd` code storage-agnostic.
+
+### utils (Support Utilities)
+- **Purpose**: Shared, storage/AWS-agnostic helpers used across commands.
+- **Responsibilities**: Process Bedrock's `ConverseStream` event stream into text; read/validate local image files for attachment; decode base64 image responses; read piped stdin as a "document"; render an interactive terminal text input box (BubbleTea-based) for the chat loop.

--- a/aidlc-docs/inception/reverse-engineering/code-quality-assessment.md
+++ b/aidlc-docs/inception/reverse-engineering/code-quality-assessment.md
@@ -1,0 +1,42 @@
+# Code Quality Assessment
+
+## Test Coverage
+
+- **Overall**: Fair — concentrated in lower layers, thin at the CLI layer (per CLAUDE.md's documented baseline, which this assessment did not independently re-run):
+  - **Repository**: 80.6%
+  - **Config**: 77.2%
+  - **Utils**: 46.6%
+  - **CMD**: 7.4%
+- **Unit Tests**: Present for `config`, `repository`, `utils` (incl. the BubbleTea input widget), and `cmd` (`cmd_test.go`), run via `go test ./... -v` (`make test`).
+- **Integration Tests**: `integration_test.go` at repo root, gated behind the `integration` build tag, exercises the compiled binary (`make cli && go test -tags=integration -v`) — covers real CLI invocation paths that unit tests can't (flag parsing end-to-end, help output, etc.).
+
+## Code Quality Indicators
+
+- **Linting**: Configured two ways with different strictness — `make lint` runs only `go vet` + `go fmt`, while `.golangci.yml` defines a much broader ruleset (gosec, staticcheck, errcheck, gocritic, unparam, prealloc, etc.) presumably run in CI. No `.github/workflows/` directory exists in this checkout, so it's unclear whether/where the stricter golangci-lint config is actually enforced — worth confirming before relying on it as a safety net.
+- **Code Style**: Consistent — idiomatic Cobra command layout, consistent `init()` registration pattern, consistent error handling style (`log.Fatalf` for CLI-fatal errors).
+- **Documentation**: Fair — package-level doc comments are sparse (most files just have a copyright header), but `README.md` and `docs/` (Sphinx site) are thorough for end-user-facing usage. `CLAUDE.md` documents architecture/workflow well for contributors.
+
+## Technical Debt
+
+- **`cmd/modelsList.go:35`** — `listModels()` hardcodes `config.WithRegion("us-east-1")` instead of reading the `--region` persistent flag like every other command does. Running `chat-cli models list --region eu-west-1` silently ignores the flag and always queries `us-east-1`.
+- **`cmd/version.go:20`** — Version string is hardcoded (`v0.5.3`) with a comment "until there is a better way to do this," so it must be manually bumped in lockstep with releases; drift from `.goreleaser.yaml`-produced tags is possible.
+- **`repository/base.go`** — The generic `Repository[T]` interface declares `GetByID`, `Update`, `Delete`, but `ChatRepository` only implements `Create`, `List`, `GetMessages`. The interface is effectively aspirational/unused today (nothing in the codebase assigns a `ChatRepository` to a `Repository[Chat]`-typed variable), which is worth resolving — either implement the missing methods or narrow the interface to what's actually used.
+- **Duplicated model-validation logic** — `chat.go`, `prompt.go`, and `image.go` each repeat near-identical blocks for loading AWS config, calling `bedrock.GetFoundationModel`, and checking output/input modalities and streaming support. A shared helper in `utils` or a new `bedrockclient` package would reduce triplication and drift risk (e.g. the `modelsList.go` region bug above is exactly the kind of drift this duplication invites).
+- **`.goreleaser.yaml.backup`** — A stray backup file sits at the repo root differing from `.goreleaser.yaml` only by `CGO_ENABLED=1` vs `0` (a relic of the CGO→pure-Go SQLite migration, commit `148fefb`). It's untracked-looking cruft that should probably be deleted now that the migration is complete.
+- **README/go.mod version drift** — `README.md` says "You will need Go v1.22.1 installed," but `go.mod` requires `go 1.23.4`. Minor but could confuse new contributors following the README literally.
+- **`github.com/satori/go.uuid` (v1.2.0)** — This UUID library is effectively unmaintained (last significant activity years ago; several known forks exist because of it). Low risk today (only used for one `NewV4()` call in `chat.go`), but worth a future swap to `google/uuid` (already an indirect dependency via other packages) to shrink the dependency surface and drop an unmaintained direct dependency.
+- **No CI workflow found in-repo** — No `.github/workflows/` directory was present in this checkout, despite `.golangci.yml`, GoReleaser config, and a documented `make lint`/`make test-coverage` workflow that strongly implies CI exists somewhere. If CI is defined outside this repo (e.g. a separate config) that's fine, but if not, the stricter `.golangci.yml` ruleset may not be enforced anywhere.
+
+## Patterns and Anti-patterns
+
+- **Good Patterns**:
+  - Clean layering: `cmd` → `config`/`factory`/`repository`/`utils`, with `db` as a storage-agnostic interface boundary (easy to add Postgres later without touching `cmd`).
+  - Path-traversal protection in `utils.ReadImage` (validates the resolved path stays within the working directory before reading).
+  - TTY-aware input (`utils.StringPrompt`/`LoadDocument`) — gracefully degrades from the fancy Bubble Tea input box to plain buffered stdin when not attached to a terminal, which is what makes `cat file | chat-cli prompt "..."` work.
+  - Config precedence is implemented once (`FileManager.GetConfigValue`) and reused consistently by `chat` and `prompt`.
+  - Deferred `Close()` with logged (not fatal) errors for DB and row-set cleanup — avoids masking the primary error path while still surfacing cleanup failures.
+
+- **Anti-patterns**:
+  - Hardcoded region in `modelsList.go` (see Technical Debt above) — functional bug, not just style.
+  - Repeated ~30-line model-validation blocks across three command files (see Technical Debt above) — classic copy-paste drift risk.
+  - `cmd/models.go`'s parent command `Run` just prints `"models called"` — effectively dead/placeholder code since `models list` is the only meaningful subcommand; harmless but a bit of clutter.

--- a/aidlc-docs/inception/reverse-engineering/code-structure.md
+++ b/aidlc-docs/inception/reverse-engineering/code-structure.md
@@ -1,0 +1,138 @@
+# Code Structure
+
+## Build System
+
+- **Type**: Go Modules (`go build`), orchestrated by a `Makefile`; releases built with GoReleaser.
+- **Configuration**:
+  - `go.mod` / `go.sum` — module `github.com/chat-cli/chat-cli`, Go 1.23.4.
+  - `Makefile` — targets: `cli` (build to `./bin/chat-cli`), `test`, `test-coverage`, `test-short`, `benchmark`, `clean-test`, `lint` (`go vet` + `go fmt`), `clean`.
+  - `.golangci.yml` — richer lint ruleset (gofmt, goimports, govet, errcheck, staticcheck, unused, gosimple, ineffassign, gosec, misspell, unparam, nakedret, prealloc, copyloopvar, gocritic) used in CI, beyond the plain `make lint`.
+  - `.goreleaser.yaml` — multi-OS/arch binary + Homebrew tap release automation.
+  - `.readthedocs.yaml` + `docs/` — Sphinx-based documentation site.
+
+## Key Classes/Modules
+
+```mermaid
+flowchart TD
+    main["main.go"] --> cmdPkg["cmd package"]
+    cmdPkg --> root["rootCmd"]
+    root --> chat["chatCmd"]
+    chat --> chatList["chatListCmd"]
+    root --> prompt["promptCmd"]
+    root --> image["imageCmd"]
+    root --> models["modelsCmd"]
+    models --> modelsList["modelsListCmd"]
+    root --> config["configCmd"]
+    config --> configSet["configSetCmd"]
+    config --> configUnset["configUnsetCmd"]
+    config --> configList["configListCmd"]
+    root --> version["versionCmd"]
+
+    cmdPkg --> configFM["config.FileManager"]
+    cmdPkg --> factoryPkg["factory.CreateDatabase"]
+    cmdPkg --> utilsPkg["utils package"]
+
+    factoryPkg --> dbIface["db.Database interface"]
+    dbIface --> sqliteImpl["sqlite.SQLiteDB"]
+    sqliteImpl --> sqliteMig["sqlite.SQLiteMigration"]
+
+    cmdPkg --> repoChat["repository.ChatRepository"]
+    repoChat --> repoBase["repository.BaseRepository"]
+    repoBase --> dbIface
+```
+
+### Text Alternative
+```
+main.go -> cmd package
+  cmd: rootCmd -> chatCmd -> chatListCmd
+              -> promptCmd
+              -> imageCmd
+              -> modelsCmd -> modelsListCmd
+              -> configCmd -> configSetCmd, configUnsetCmd, configListCmd
+              -> versionCmd
+  cmd depends on: config.FileManager, factory.CreateDatabase, utils package,
+                  repository.ChatRepository
+  factory.CreateDatabase -> db.Database interface -> sqlite.SQLiteDB -> sqlite.SQLiteMigration
+  repository.ChatRepository -> repository.BaseRepository -> db.Database interface
+```
+
+### Existing Files Inventory
+
+- `main.go` - Entry point; calls `cmd.Execute()`.
+- `integration_test.go` - Build-tagged (`integration`) end-to-end CLI tests against the compiled binary.
+- `cmd/root.go` - Base Cobra command; when run without subcommands, delegates straight to `chatCmd.Run`. Defines all shared persistent flags (`--region`, `--model-id`, `--custom-arn`, `--chat-id`, `--temperature`, `--topP`, `--max-tokens`).
+- `cmd/chat.go` - Interactive chat command: loads config, opens DB, validates/resolves model, replays prior messages if `--chat-id` set, runs the streaming input/output loop, persists every turn.
+- `cmd/chatList.go` - `chat list` subcommand: prints the 10 most recent chat sessions as a table.
+- `cmd/prompt.go` - `prompt` command: one-shot prompt with optional stdin document, optional image attachment, streaming or `--no-stream` full response.
+- `cmd/image.go` - `image` command: generates an image via Stability AI or Amazon Titan image models and writes it to disk.
+- `cmd/models.go` - `models` parent command (placeholder `Run` that just prints "models called").
+- `cmd/modelsList.go` - `models list` subcommand: lists all foundation models available in the region via Bedrock control-plane API.
+- `cmd/config.go` - `config` command group: `set`, `unset`, `list` for persisted `model-id`/`custom-arn` values, backed by Viper + direct YAML file edits.
+- `cmd/version.go` - `version` command: prints a hardcoded version string + OS/arch.
+- `cmd/cmd_test.go` - Unit tests for the `cmd` package (see code-quality-assessment.md for coverage).
+- `config/config.go` - `FileManager`: resolves OS-specific config/data directories, initializes Viper, implements config value precedence (`GetConfigValue`).
+- `config/config_test.go` - Unit tests for `FileManager`.
+- `db/db.go` - `Database` interface + shared `Config` struct.
+- `db/migrations.go` - `Migration` interface (`MigrateUp`/`MigrateDown`).
+- `db/sqlite/sqlite.go` - `SQLiteDB`: implements `db.Database` using `modernc.org/sqlite` (pure-Go, no CGO).
+- `db/sqlite/migrations.go` - `SQLiteMigration`: creates the `chats` table + `updated_at` trigger.
+- `factory/database.go` - `CreateDatabase`: driver-selection factory (only `sqlite` currently implemented; `postgres` stubbed as a comment).
+- `repository/base.go` - Generic `Repository[T]` interface + `BaseRepository` struct (holds a `db.Database`).
+- `repository/chat.go` - `Chat` model + `ChatRepository` (`Create`, `List`, `GetMessages`).
+- `repository/chat_test.go` - Unit tests for `ChatRepository`.
+- `utils/utils.go` - `ProcessStreamingOutput`, `ReadImage`, `DecodeImage`, `StringPrompt`, `LoadDocument`.
+- `utils/utils_test.go` - Unit tests for the above.
+- `utils/bubbleinput.go` - `InputField` BubbleTea model + `BubbleInput()` — the interactive terminal text box used by the chat loop.
+- `utils/bubbleinput_test.go` - Unit tests for the input widget.
+
+## Design Patterns
+
+### Repository Pattern
+- **Location**: `repository/base.go`, `repository/chat.go`
+- **Purpose**: Decouple command code from SQL/storage details; generic `Repository[T]` interface intended to be reused for future entity types beyond `Chat`.
+- **Implementation**: `ChatRepository` embeds `BaseRepository` (which holds a `db.Database`); only `Chat`-specific methods (`Create`, `List`, `GetMessages`) are implemented — `GetByID`, `Update`, `Delete` from the generic interface are not yet implemented for `Chat`.
+
+### Factory Pattern
+- **Location**: `factory/database.go`
+- **Purpose**: Let calling code obtain a working `db.Database` without knowing which concrete driver is configured.
+- **Implementation**: `CreateDatabase(config)` switches on `config.Driver`; currently only handles `"sqlite"`, connects it, and returns the interface. A `"postgres"` case is commented out as a placeholder for future multi-database support.
+
+### Interface Segregation / Dependency Inversion
+- **Location**: `db/db.go` (`Database` interface), `db/migrations.go` (`Migration` interface)
+- **Purpose**: Keep `cmd` and `repository` packages storage-agnostic so a new backend can be added by implementing the interfaces, without touching calling code.
+- **Implementation**: `sqlite.SQLiteDB` and `sqlite.SQLiteMigration` implement these interfaces; nothing outside `db/sqlite` references `modernc.org/sqlite` directly.
+
+### Command Pattern (via Cobra)
+- **Location**: All of `cmd/`
+- **Purpose**: Each CLI command/subcommand is a self-contained `*cobra.Command` with its own `init()` registering flags and wiring into its parent — a standard, idiomatic Cobra layout.
+- **Implementation**: `root.go` special-cases the no-subcommand invocation to fall through to `chatCmd.Run`, so `chat-cli` alone behaves like `chat-cli chat` (but chat flags are duplicated onto `rootCmd` so they work at the top level too).
+
+## Critical Dependencies
+
+### github.com/spf13/cobra (v1.8.1)
+- **Usage**: All CLI command/flag definitions across `cmd/`.
+- **Purpose**: Standard Go CLI framework providing subcommands, flag parsing, help text generation.
+
+### github.com/spf13/viper (v1.19.0)
+- **Usage**: `config/config.go` — backs `FileManager`'s persisted YAML config.
+- **Purpose**: Config file read/write with defaults and precedence support.
+
+### github.com/aws/aws-sdk-go-v2 (+ bedrock, bedrockruntime, config) (v1.32.6 / v1.25.0 / v1.23.0 / v1.28.6)
+- **Usage**: Every command that talks to Bedrock (`chat`, `prompt`, `image`, `models list`).
+- **Purpose**: AWS credential resolution, Bedrock control-plane (model listing/details) and runtime (Converse/ConverseStream/InvokeModel) calls.
+
+### modernc.org/sqlite (v1.38.2)
+- **Usage**: `db/sqlite/sqlite.go`.
+- **Purpose**: Pure-Go (CGO-free) SQLite driver for `database/sql` — chosen specifically to avoid CGO cross-compilation issues (see commit history: "Switch to pure Go SQLite driver ... Fix SQLite CGO compilation error").
+
+### github.com/charmbracelet/bubbletea, bubbles, lipgloss (v1.3.6 / v0.21.0 / v1.1.0)
+- **Usage**: `utils/bubbleinput.go`.
+- **Purpose**: TUI framework powering the interactive multi-line input box used in the chat loop.
+
+### github.com/satori/go.uuid (v1.2.0)
+- **Usage**: `cmd/chat.go` — generates a new chat session UUID when `--chat-id` isn't supplied.
+- **Purpose**: Chat session identification.
+
+### github.com/go-micah/go-bedrock (v0.2.0)
+- **Usage**: `cmd/image.go` — `providers.StabilityAIStableDiffusionInvokeModelInput/Output`, `providers.AmazonTitanImageInvokeModelInput/Output`.
+- **Purpose**: Typed request/response bodies for image-generation model providers (Bedrock's `InvokeModel` takes raw JSON, so this package supplies the provider-specific schemas).

--- a/aidlc-docs/inception/reverse-engineering/component-inventory.md
+++ b/aidlc-docs/inception/reverse-engineering/component-inventory.md
@@ -1,0 +1,30 @@
+# Component Inventory
+
+## Application Packages
+- `cmd` - CLI command layer (root, chat, chat list, prompt, image, models, models list, config set/unset/list, version)
+- `main` - Entry point (`main.go`), delegates to `cmd.Execute()`
+
+## Infrastructure Packages
+- None — this is a client application with no IaC/deployment packages in-repo. Release infrastructure is config-only: `.goreleaser.yaml` (binary + Homebrew tap publishing).
+
+## Shared Packages
+- `config` - Utilities/FileManager for OS-specific config & data paths, Viper-backed persisted settings
+- `db` - Storage-agnostic interfaces (`Database`, `Migration`) and shared `Config` struct
+- `db/sqlite` - SQLite driver implementation of the `db` interfaces
+- `factory` - Database driver factory (`CreateDatabase`)
+- `repository` - Generic `Repository[T]` interface + `ChatRepository` (Chat persistence)
+- `utils` - Streaming response processing, image IO, stdin document loading, interactive terminal input widget (Clients: consumed by `cmd` for all Bedrock/image/input interactions)
+
+## Test Packages
+- `cmd` (`cmd_test.go`) - Unit tests for CLI command package
+- `config` (`config_test.go`) - Unit tests for `FileManager`
+- `repository` (`chat_test.go`) - Unit tests for `ChatRepository`
+- `utils` (`utils_test.go`, `bubbleinput_test.go`) - Unit tests for utility functions and the input widget
+- root (`integration_test.go`) - Build-tag `integration` end-to-end tests against the compiled `chat-cli` binary
+
+## Total Count
+- **Total Packages**: 8 (main, cmd, config, db, db/sqlite, factory, repository, utils)
+- **Application**: 2 (main, cmd)
+- **Infrastructure**: 0
+- **Shared**: 5 (config, db, db/sqlite, factory, repository, utils — repository counted here as it's an internal persistence abstraction consumed by cmd)
+- **Test**: Test files co-located within cmd, config, repository, utils, plus root-level `integration_test.go` (no separate test packages/directories)

--- a/aidlc-docs/inception/reverse-engineering/dependencies.md
+++ b/aidlc-docs/inception/reverse-engineering/dependencies.md
@@ -1,0 +1,103 @@
+# Dependencies
+
+## Internal Dependencies
+
+```mermaid
+flowchart TD
+    main["main"] --> cmd["cmd"]
+    cmd --> config["config"]
+    cmd --> db["db"]
+    cmd --> sqlite["db/sqlite"]
+    cmd --> factory["factory"]
+    cmd --> repository["repository"]
+    cmd --> utils["utils"]
+    factory --> db
+    factory --> sqlite
+    sqlite --> db
+    repository --> db
+```
+
+### Text Alternative
+```
+main -> cmd
+cmd -> config, db, db/sqlite, factory, repository, utils
+factory -> db, db/sqlite
+db/sqlite -> db
+repository -> db
+```
+
+### `cmd` depends on `config`
+- **Type**: Compile
+- **Reason**: Every command that touches persisted settings (`chat`, `chat list`, `prompt`, `config`) needs `FileManager` for OS paths, Viper init, and config precedence.
+
+### `cmd` depends on `db`, `db/sqlite`, `factory`
+- **Type**: Compile
+- **Reason**: `chat` and `chat list` need a live database connection; `factory.CreateDatabase` returns a `db.Database` backed transparently by `db/sqlite`.
+
+### `cmd` depends on `repository`
+- **Type**: Compile
+- **Reason**: `chat` and `chat list` use `ChatRepository` to read/write conversation history instead of writing raw SQL inline.
+
+### `cmd` depends on `utils`
+- **Type**: Compile
+- **Reason**: `chat`, `prompt`, `image` all need streaming output processing and/or image IO and/or the interactive input widget.
+
+### `factory` depends on `db`, `db/sqlite`
+- **Type**: Compile
+- **Reason**: Implements the driver-selection switch that returns a `db.Database`; today only wires up the `db/sqlite` implementation.
+
+### `db/sqlite` depends on `db`
+- **Type**: Compile
+- **Reason**: `SQLiteDB`/`SQLiteMigration` implement the `db.Database`/`db.Migration` interfaces.
+
+### `repository` depends on `db`
+- **Type**: Compile
+- **Reason**: `BaseRepository` holds a `db.Database` so repositories can execute queries without knowing the concrete driver.
+
+## External Dependencies
+
+### github.com/aws/aws-sdk-go-v2 (v1.32.6) + submodules
+- **Version**: `config` v1.28.6, `service/bedrock` v1.25.0, `service/bedrockruntime` v1.23.0
+- **Purpose**: AWS credential/config resolution and Bedrock control-plane/runtime API clients — the core external integration of the whole product.
+- **License**: Apache-2.0
+
+### github.com/spf13/cobra (v1.8.1)
+- **Purpose**: CLI command/flag framework underpinning all of `cmd/`.
+- **License**: Apache-2.0
+
+### github.com/spf13/viper (v1.19.0)
+- **Purpose**: Configuration file management.
+- **License**: MIT
+
+### github.com/charmbracelet/bubbletea (v1.3.6), bubbles (v0.21.0), lipgloss (v1.1.0)
+- **Purpose**: TUI framework and components for the interactive chat input box.
+- **License**: MIT
+
+### modernc.org/sqlite (v1.38.2)
+- **Purpose**: Pure-Go SQLite driver, avoids CGO to keep cross-compilation simple for GoReleaser (replaced a CGO-based driver per commit `148fefb`/`561ecf2`).
+- **License**: BSD-3-Clause (plus bundled SQLite public-domain source)
+
+### github.com/satori/go.uuid (v1.2.0)
+- **Purpose**: Chat session UUID generation.
+- **License**: MIT
+- **Note**: This library is effectively unmaintained (archived) — a known ecosystem concern worth revisiting (see code-quality-assessment.md).
+
+### github.com/mattn/go-isatty (v0.0.20)
+- **Purpose**: TTY detection to switch between interactive (BubbleInput) and piped (stdin buffer) input modes.
+- **License**: MIT
+
+### github.com/go-micah/go-bedrock (v0.2.0)
+- **Purpose**: Provider-specific request/response types for Bedrock image models (Stability AI, Amazon Titan).
+- **License**: MIT (author-maintained companion library, smaller ecosystem footprint than the AWS SDK)
+
+### golang.org/x/term (v0.33.0)
+- **Purpose**: Terminal size detection for the input widget.
+- **License**: BSD-3-Clause
+
+### gopkg.in/yaml.v3 (v3.0.1)
+- **Purpose**: Manual YAML marshal/unmarshal for `config unset` (removing a single key without Viper support for that operation).
+- **License**: MIT/Apache-2.0 dual
+
+### Transitive dependencies (~35 indirect modules)
+- **Purpose**: Pulled in by Cobra/Viper (`fsnotify`, `afero`, `pelletier/go-toml`, `hashicorp/hcl`, `magiconair/properties`, `subosito/gotenv`, `sagikazarmark/locafero`, etc.), AWS SDK (`smithy-go`, credential/endpoint internals), Bubble Tea ecosystem (`muesli/*`, `charmbracelet/x/*`, `erikgeiser/coninput`, `lucasb-eyer/go-colorful`, `atotto/clipboard`), and `modernc.org/sqlite` (`modernc.org/libc`, `mathutil`, `memory`, `ncruces/go-strftime`, `remyoudompheng/bigfft`).
+- **Purpose**: Standard, low-risk supporting libraries for the frameworks above — no direct application code references them.

--- a/aidlc-docs/inception/reverse-engineering/reverse-engineering-timestamp.md
+++ b/aidlc-docs/inception/reverse-engineering/reverse-engineering-timestamp.md
@@ -1,0 +1,16 @@
+# Reverse Engineering Metadata
+
+**Analysis Date**: 2026-07-08T00:00:00Z
+**Analyzer**: AI-DLC
+**Workspace**: /home/user/chat-cli
+**Total Files Analyzed**: 26 Go source files (~3,372 lines) plus build/config/docs files (go.mod, Makefile, .golangci.yml, .goreleaser.yaml, README.md, CLAUDE.md)
+
+## Artifacts Generated
+- [x] business-overview.md
+- [x] architecture.md
+- [x] code-structure.md
+- [x] api-documentation.md
+- [x] component-inventory.md
+- [x] technology-stack.md
+- [x] dependencies.md
+- [x] code-quality-assessment.md

--- a/aidlc-docs/inception/reverse-engineering/technology-stack.md
+++ b/aidlc-docs/inception/reverse-engineering/technology-stack.md
@@ -1,0 +1,28 @@
+# Technology Stack
+
+## Programming Languages
+- Go - 1.23.4 (per `go.mod`; README build instructions mention 1.22.1 as the minimum — see code-quality-assessment.md for this drift)
+
+## Frameworks
+- Cobra (`github.com/spf13/cobra` v1.8.1) - CLI command/flag framework, root of the entire `cmd` package
+- Viper (`github.com/spf13/viper` v1.19.0) - Configuration file management (YAML) with precedence support
+- Bubble Tea (`github.com/charmbracelet/bubbletea` v1.3.6) - TUI event loop framework for the interactive input widget
+- Bubbles (`github.com/charmbracelet/bubbles` v0.21.0) - Pre-built TUI components (`textarea`) used by the input widget
+- Lip Gloss (`github.com/charmbracelet/lipgloss` v1.1.0) - Terminal styling (borders, colors) for the input widget
+
+## Infrastructure
+- Amazon Bedrock - Foundation model hosting; both control-plane (`bedrock`) and runtime/inference (`bedrockruntime`) APIs are used
+- AWS SDK for Go v2 (`github.com/aws/aws-sdk-go-v2` v1.32.6 + `config` v1.28.6) - AWS credential resolution and service clients
+- SQLite (via `modernc.org/sqlite` v1.38.2, pure-Go/CGO-free) - Local chat history persistence; no external database server
+- GoReleaser (`.goreleaser.yaml`) - Cross-platform binary builds and Homebrew tap publishing
+- ReadTheDocs / Sphinx (`.readthedocs.yaml`, `docs/`) - Hosted documentation site build
+
+## Build Tools
+- Go Modules - Dependency management (`go.mod`/`go.sum`)
+- Make - Build/test/lint orchestration (`Makefile`)
+- golangci-lint (config in `.golangci.yml`) - Extended static analysis (used in CI; not directly invoked by `make lint`, which runs plain `go vet` + `go fmt`)
+
+## Testing Tools
+- Go `testing` package (standard library) - All unit and integration tests
+- Go build tags (`integration`) - Separates integration tests (`integration_test.go`) from unit tests, gated behind a compiled binary
+- `go tool cover` - Coverage report generation (`make test-coverage` → `coverage.out`/`coverage.html`)


### PR DESCRIPTION
Runs the AI-DLC Workspace Detection + Reverse Engineering stages
against the existing codebase to produce business, architecture,
code-structure, API, component, tech-stack, dependency, and code
quality artifacts under aidlc-docs/, as groundwork for scoping new
development work.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Hxx6CHPFfwPpgF8uX7a9Q