### PR TITLE
Use deploy key for Homebrew tap release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,8 @@ brews:
     repository:
       owner: chat-cli
       name: homebrew-chat-cli
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      git:
+        url: ssh://git@github.com/chat-cli/homebrew-chat-cli.git
+        private_key: "{{ .Env.HOMEBREW_TAP_DEPLOY_KEY }}"
     description: "chat-cli is a command line tool for working with llms on Amazon Bedrock"
     homepage: "https://github.com/chat-cli/chat-cli/"

--- a/aidlc-docs/construction/issue-98-release-automation/summary.md
+++ b/aidlc-docs/construction/issue-98-release-automation/summary.md
@@ -13,7 +13,7 @@
 - Plan: `aidlc-docs/inception/plans/issue-98-execution-plan.md`
 
 ## Manual Setup Required After Merge
-1. Add `HOMEBREW_TAP_GITHUB_TOKEN` secret (PAT with push to `chat-cli/homebrew-chat-cli`)
+1. Add `HOMEBREW_TAP_DEPLOY_KEY` secret (write deploy key on `chat-cli/homebrew-chat-cli`)
 2. Optionally enable branch protection requiring CI on `main`
 
 ## Verification

--- a/aidlc-docs/inception/plans/issue-98-execution-plan.md
+++ b/aidlc-docs/inception/plans/issue-98-execution-plan.md
@@ -21,7 +21,7 @@ Single unit — DevOps / CI. No application logic changes beyond version ldflags
 5. Verify locally: `make test`, `make cli`, `goreleaser release --snapshot` (if goreleaser installed)
 
 ## Post-merge Setup (manual, documented)
-- Add repo secret `HOMEBREW_TAP_GITHUB_TOKEN` with push access to `homebrew-chat-cli`
+- Add repo secret `HOMEBREW_TAP_DEPLOY_KEY` (write deploy key on `homebrew-chat-cli`)
 - Optional: enable branch protection requiring CI on `main`
 
 ## Out of Scope

--- a/aidlc-docs/inception/requirements/issue-98-release-automation.md
+++ b/aidlc-docs/inception/requirements/issue-98-release-automation.md
@@ -31,7 +31,7 @@ Brownfield DevOps change — no application feature changes. Automate CI and rel
 
 ### NFR1 — Secrets
 - `GITHUB_TOKEN` (default) for release assets in this repo.
-- `HOMEBREW_TAP_GITHUB_TOKEN` — PAT with push access to `chat-cli/homebrew-chat-cli`.
+- `HOMEBREW_TAP_DEPLOY_KEY` — SSH private key for a write deploy key on `chat-cli/homebrew-chat-cli`.
 
 ### NFR2 — No release on every main merge
 - Auto-releasing every merge produces too many versions; use explicit tag/dispatch instead.

--- a/docs/release.md
+++ b/docs/release.md
@@ -59,9 +59,32 @@ Configure these in **Settings → Secrets and variables → Actions**:
 | Secret | Purpose |
 |--------|---------|
 | `GITHUB_TOKEN` | Provided automatically; publishes release assets to this repo |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | PAT with push access to `chat-cli/homebrew-chat-cli` |
+| `HOMEBREW_TAP_DEPLOY_KEY` | SSH private key (write deploy key on `chat-cli/homebrew-chat-cli`) |
 
-Without `HOMEBREW_TAP_GITHUB_TOKEN`, GoReleaser still publishes GitHub Release binaries but cannot update the Homebrew tap.
+Without `HOMEBREW_TAP_DEPLOY_KEY`, GoReleaser still publishes GitHub Release binaries but cannot update the Homebrew tap.
+
+### Homebrew tap deploy key (one-time setup)
+
+Generate a dedicated key (no passphrase):
+
+```bash
+ssh-keygen -t ed25519 -C "goreleaser-homebrew-tap" -f ~/.ssh/chat-cli-homebrew-tap -N ""
+```
+
+Add the public key to the tap repo with write access:
+
+```bash
+gh repo deploy-key add ~/.ssh/chat-cli-homebrew-tap.pub \
+  --repo chat-cli/homebrew-chat-cli \
+  --title "GoReleaser release automation" \
+  --allow-write
+```
+
+Store the private key as a repository secret:
+
+```bash
+gh secret set HOMEBREW_TAP_DEPLOY_KEY --repo chat-cli/chat-cli < ~/.ssh/chat-cli-homebrew-tap
+```
 
 ## Local GoReleaser (optional)
 


### PR DESCRIPTION
## Summary

- Switch GoReleaser Homebrew tap publishing from PAT to SSH deploy key (`HOMEBREW_TAP_DEPLOY_KEY`)
- Update release workflow and `docs/release.md` with deploy key setup instructions

Org repos disable deploy keys by default; deploy keys are now enabled for `chat-cli` and the write key is configured on `homebrew-chat-cli`. The private key is stored as `HOMEBREW_TAP_DEPLOY_KEY` on this repo.

## Test plan

- [x] Deploy key added to `chat-cli/homebrew-chat-cli` (write access)
- [x] `HOMEBREW_TAP_DEPLOY_KEY` secret set on `chat-cli/chat-cli`
- [ ] Merge PR
- [ ] Run **Tag Release** workflow (patch) and verify Homebrew formula update in `homebrew-chat-cli`