### PR TITLE
Run GoReleaser in Tag Release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,6 +1,7 @@
 name: Tag Release
 
-# Bumps semver, runs tests, and pushes a v* tag. The Release workflow runs on tag push.
+# Bumps semver, runs tests, tags, publishes with GoReleaser, then pushes the tag.
+# GoReleaser runs here because tag pushes made with GITHUB_TOKEN do not trigger other workflows.
 on:
   workflow_dispatch:
     inputs:
@@ -55,9 +56,21 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
           echo "Next tag: $next (after $latest)"
 
-      - name: Create and push tag
+      - name: Create tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.next.outputs.next }}"
-          git push origin "${{ steps.next.outputs.next }}"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+
+      - name: Push tag
+        run: git push origin "${{ steps.next.outputs.next }}"

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,8 +23,8 @@ Releases are **tag-driven**, not automatic on every merge to `main`.
 1. Merge changes to `main` and confirm CI is green.
 2. Open **Actions → Tag Release → Run workflow**.
 3. Choose bump level: `patch`, `minor`, or `major`.
-4. The workflow runs tests, creates a `v*` tag, and pushes it.
-5. The **Release** workflow runs automatically on the new tag and invokes GoReleaser.
+4. The workflow runs tests, tags locally, publishes with GoReleaser, then pushes the `v*` tag.
+5. Manual tag pushes (Option B) still trigger the separate **Release** workflow.
 
 ### Option B — Manual tag
 


### PR DESCRIPTION
## Summary

- Run GoReleaser in `tag-release.yml` after creating the tag locally
- Push the tag after publish completes
- Document that manual tag pushes still use the separate Release workflow

Fixes the gap discovered during v0.5.4 E2E testing: tag pushes made with `GITHUB_TOKEN` do not trigger the Release workflow.

## Test plan

- [x] v0.5.4 release verified manually (re-pushed tag triggered Release workflow)
- [ ] Merge and run Tag Release (patch) to confirm one-click flow works without manual intervention