### PR TITLE
Add automatic AGENTS.md/CLAUDE.md project-context discovery to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The configuration system follows a clear precedence order:
 - `model-id`: The default model identifier to use for chat and prompt commands
 - `custom-arn`: A custom ARN from Bedrock marketplace or for cross-region inference
 - `system-prompt`: The default system prompt to use for chat and prompt commands
+- `context-files`: Comma-separated list of project-context filenames to look for, overriding the default `AGENTS.md,CLAUDE.md,.github/copilot-instructions.md` list (see [Project Context](#project-context))
 
 ## System Prompt
 
@@ -137,6 +138,23 @@ You can also set a default system prompt so you don't have to pass `--system` ev
 ```
 
 The same precedence rules as `model-id`/`custom-arn` apply: `--system` flag, then the persisted config value, then no system prompt at all.
+
+## Project Context
+
+If neither `--system` nor `system-prompt` is set, `chat` automatically looks for a project-context file and uses it as the system prompt - no flag needed. It checks, in order, `AGENTS.md`, `CLAUDE.md`, then `.github/copilot-instructions.md`, first in your current directory and then (if not found there) at your repository root. The first match wins - files aren't merged.
+
+```shell
+    chat-cli
+    # Using project context: AGENTS.md
+```
+
+Customize the filenames checked (and their order) via the `context-files` config value:
+
+```shell
+    chat-cli config set context-files "AGENTS.md,CLAUDE.md"
+```
+
+Disable discovery for one session with `--no-context-file`, or by default with `chat-cli config set context-files ""`. Content over 32KB is truncated with a warning. This is `chat`-only for now; `prompt` isn't affected.
 
 ## Tool Use
 

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -196,7 +196,9 @@ No PR opened (not requested by user). Recommended before merge: run the
   - Clarifying questions answered by user (chat-only scope, automatic activation, explicit-system-wins precedence, Cursor dropped from scope, walk-up-to-.git left to AI judgment)
   - Artifacts: aidlc-docs/inception/requirements/agents-md-convention-questions.md, aidlc-docs/inception/requirements/agents-md-convention-requirements.md
   - FR1-FR6 + NFR1-NFR5 documented; Out of Scope section captures prompt-command support, Cursor's real .mdc convention, and README.md-as-default as explicit non-goals for this pass
-- [ ] User Stories - RECOMMENDED SKIP (single cohesive feature, one persona already established in Initiative 1, requirements already concrete with FR-level acceptance detail) - offered as an option in completion message per core-workflow.md
-- [ ] Workflow Planning - TBD
-- [ ] Application Design - TBD (likely lightweight - single unit)
-- [ ] Units Generation - TBD (likely SKIP - naturally one unit of work, no parallelization benefit)
+- [x] User Stories - SKIPPED (approved by user via "Approve and continue" without requesting the stage be added)
+- [x] Workflow Planning - Completed 2026-07-08, awaiting user approval
+  - Artifacts: aidlc-docs/inception/plans/agents-md-convention-execution-plan.md
+  - Risk: Low. Application Design SKIP, Units Generation SKIP (single unit, no new subsystem shape). Functional Design + NFR combined EXECUTE. Code Generation + Build and Test ALWAYS EXECUTE.
+- [ ] Application Design - SKIP (see execution plan rationale)
+- [ ] Units Generation - SKIP (see execution plan rationale, this initiative proceeds as a single implicit unit straight into Construction)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -210,6 +210,9 @@ No PR opened (not requested by user). Recommended before merge: run the
 - [x] NFR Requirements + Design - Completed 2026-07-08 (combined presentation, same pattern as Initiative 1 Units 2/4), awaiting user approval
   - Artifacts: aidlc-docs/construction/agents-md-convention/nfr-requirements/nfr-requirements-and-design.md
   - Security: bounded to 2 directories, no path-traversal surface (fixed filenames only, no user-supplied path). Reliability: filesystem failures degrade to "no match," never fatal.
-- [ ] Infrastructure Design - SKIP (no infrastructure in this project, decided globally)
-- [ ] Code Generation - Pending approval of Functional Design + NFR
-- [ ] Build and Test - Pending Code Generation
+- [x] Infrastructure Design - SKIP (no infrastructure in this project, decided globally)
+- [x] Code Generation - Completed 2026-07-08, awaiting user review/approval
+  - Plan: aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md (all 14 steps complete)
+  - Summary: aidlc-docs/construction/agents-md-convention/code/summary.md
+  - cmd coverage 23.6% -> 31.8%, total 66.3% -> 67.8%, no regressions. All 7 integration tests pass. Manual smoke test confirmed discovery, --system suppression, and --no-context-file suppression all work end-to-end.
+- [ ] Build and Test - Pending final approval

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -200,5 +200,16 @@ No PR opened (not requested by user). Recommended before merge: run the
 - [x] Workflow Planning - Completed 2026-07-08, awaiting user approval
   - Artifacts: aidlc-docs/inception/plans/agents-md-convention-execution-plan.md
   - Risk: Low. Application Design SKIP, Units Generation SKIP (single unit, no new subsystem shape). Functional Design + NFR combined EXECUTE. Code Generation + Build and Test ALWAYS EXECUTE.
-- [ ] Application Design - SKIP (see execution plan rationale)
-- [ ] Units Generation - SKIP (see execution plan rationale, this initiative proceeds as a single implicit unit straight into Construction)
+- [x] Application Design - SKIP (see execution plan rationale)
+- [x] Units Generation - SKIP (see execution plan rationale, this initiative proceeds as a single implicit unit straight into Construction) - INCEPTION PHASE COMPLETE
+
+### Construction Phase - agents-md-convention (#88, single implicit unit)
+- [x] Functional Design - Completed 2026-07-08, awaiting user approval
+  - Artifacts: aidlc-docs/construction/agents-md-convention/functional-design/{business-logic-model,business-rules,domain-entities}.md
+  - Resolved FR1.2's walk-up rule into a concrete two-phase algorithm (Phase A: cheap `.git`-boundary stat-walk; Phase B: check candidates at cwd, then boundary dir only) - verified against actual cmd/chat.go:114, cmd/systemprompt.go, cmd/config.go source, not guessed
+- [x] NFR Requirements + Design - Completed 2026-07-08 (combined presentation, same pattern as Initiative 1 Units 2/4), awaiting user approval
+  - Artifacts: aidlc-docs/construction/agents-md-convention/nfr-requirements/nfr-requirements-and-design.md
+  - Security: bounded to 2 directories, no path-traversal surface (fixed filenames only, no user-supplied path). Reliability: filesystem failures degrade to "no match," never fatal.
+- [ ] Infrastructure Design - SKIP (no infrastructure in this project, decided globally)
+- [ ] Code Generation - Pending approval of Functional Design + NFR
+- [ ] Build and Test - Pending Code Generation

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -170,3 +170,31 @@ No PR opened (not requested by user). Recommended before merge: run the
 - #96 Add CI workflow to enforce lint/test on PRs
 
 **Related pre-existing open issues surfaced during triage**: #58 (file attachments, relates to #84), #46 (document in chat mode), #41 (token counts, overlaps future UX idea - not re-filed), #65 (models placeholder output, relates to #91), #21 (concept of modules, relates to #81)
+
+---
+
+# INITIATIVE 1 EPILOGUE (post-completion events, outside AI-DLC stages)
+
+- PR #97 opened for branch `claude/ai-dlc-documentation-rl4e5s` -> `main`, closing #81-#85. Merged 2026-07-08T15:07:16Z.
+- Separately, PRs #99/#100/#101 (release automation, CI workflow, Homebrew deploy key) merged to `main`, closing #98. Not part of this AI-DLC initiative's scope.
+- GitHub issue cleanup performed in conversation (not an AI-DLC stage, just tracker hygiene): #96 closed as resolved by #99's `ci.yml`; #95 closed as resolved (backup file gone, README Go version fixed). #91, #92, #93, #94, #58, #46 verified still open/unresolved on `main` and left open.
+- Branch `claude/ai-dlc-documentation-rl4e5s` reset to latest `origin/main` (`d1619d2`) to start Initiative 2 fresh, per merged-branch restart protocol - old commit history for Initiative 1 is fully captured in `main` via PR #97.
+
+---
+
+# INITIATIVE 2: Universal Project-Context File Convention (#88, redefined)
+
+## Project Information
+- **Start Date**: 2026-07-08 (same day, continued session)
+- **Trigger**: User requested Phase 2 discussion; picked #88 (project-context file), redefined scope from a chat-cli-specific `CHATCLI.md` to a universal `AGENTS.md`-first convention with fallback to other tools' conventions (`CLAUDE.md`, Cursor rules, Copilot instructions), per brainstorm discussion in this conversation.
+- **Issue #88 updated** on GitHub with the new design (title + body rewritten) before starting this initiative.
+
+## Stage Progress
+- [x] Workspace Detection - Brownfield confirmed, existing `aidlc-docs/aidlc-state.md` found (Initiative 1, complete)
+  - **Reverse engineering artifacts exist but are STALE** relative to current `main` (Initiative 1 added `tools/` package, `cmd/systemprompt.go`, `cmd/promptcache.go`, `cmd/documentinput.go`, `cmd/reasoning.go`, `cmd/toolloop.go`, SDK upgrade to v1.55.0; separately `main` gained CI/release automation). **Decision**: do NOT re-run full Reverse Engineering for this narrow, additive feature - scope is well understood from this session's own recent work (system prompt + config precedence pattern directly reused). Full RE re-run would be disproportionate to a single-feature initiative. Proceeding directly to Requirements Analysis with current-state knowledge loaded ad hoc from `cmd/systemprompt.go`, `cmd/config.go`, `cmd/promptcache.go`.
+- [ ] Requirements Analysis - IN PROGRESS, clarifying questions issued
+  - Design already substantially discussed in-conversation (precedence list, no-merge policy, config key, git-root walk-up, size guard, cache-point synergy) - requirements.md will incorporate these as settled decisions; clarifying questions target only the remaining open parameters.
+- [ ] User Stories - TBD (likely SKIP - single cohesive feature, one persona already established)
+- [ ] Workflow Planning - TBD
+- [ ] Application Design - TBD (likely lightweight - single unit)
+- [ ] Units Generation - TBD (likely SKIP - naturally one unit of work, no parallelization benefit)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -192,9 +192,11 @@ No PR opened (not requested by user). Recommended before merge: run the
 ## Stage Progress
 - [x] Workspace Detection - Brownfield confirmed, existing `aidlc-docs/aidlc-state.md` found (Initiative 1, complete)
   - **Reverse engineering artifacts exist but are STALE** relative to current `main` (Initiative 1 added `tools/` package, `cmd/systemprompt.go`, `cmd/promptcache.go`, `cmd/documentinput.go`, `cmd/reasoning.go`, `cmd/toolloop.go`, SDK upgrade to v1.55.0; separately `main` gained CI/release automation). **Decision**: do NOT re-run full Reverse Engineering for this narrow, additive feature - scope is well understood from this session's own recent work (system prompt + config precedence pattern directly reused). Full RE re-run would be disproportionate to a single-feature initiative. Proceeding directly to Requirements Analysis with current-state knowledge loaded ad hoc from `cmd/systemprompt.go`, `cmd/config.go`, `cmd/promptcache.go`.
-- [ ] Requirements Analysis - IN PROGRESS, clarifying questions issued
-  - Design already substantially discussed in-conversation (precedence list, no-merge policy, config key, git-root walk-up, size guard, cache-point synergy) - requirements.md will incorporate these as settled decisions; clarifying questions target only the remaining open parameters.
-- [ ] User Stories - TBD (likely SKIP - single cohesive feature, one persona already established)
+- [x] Requirements Analysis - Completed 2026-07-08, awaiting user approval
+  - Clarifying questions answered by user (chat-only scope, automatic activation, explicit-system-wins precedence, Cursor dropped from scope, walk-up-to-.git left to AI judgment)
+  - Artifacts: aidlc-docs/inception/requirements/agents-md-convention-questions.md, aidlc-docs/inception/requirements/agents-md-convention-requirements.md
+  - FR1-FR6 + NFR1-NFR5 documented; Out of Scope section captures prompt-command support, Cursor's real .mdc convention, and README.md-as-default as explicit non-goals for this pass
+- [ ] User Stories - RECOMMENDED SKIP (single cohesive feature, one persona already established in Initiative 1, requirements already concrete with FR-level acceptance detail) - offered as an option in completion message per core-workflow.md
 - [ ] Workflow Planning - TBD
 - [ ] Application Design - TBD (likely lightweight - single unit)
 - [ ] Units Generation - TBD (likely SKIP - naturally one unit of work, no parallelization benefit)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -215,4 +215,9 @@ No PR opened (not requested by user). Recommended before merge: run the
   - Plan: aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md (all 14 steps complete)
   - Summary: aidlc-docs/construction/agents-md-convention/code/summary.md
   - cmd coverage 23.6% -> 31.8%, total 66.3% -> 67.8%, no regressions. All 7 integration tests pass. Manual smoke test confirmed discovery, --system suppression, and --no-context-file suppression all work end-to-end.
-- [ ] Build and Test - Pending final approval
+- [x] Build and Test - Completed 2026-07-08, awaiting final approval
+  - Artifacts: aidlc-docs/construction/build-and-test/agents-md-convention-summary.md
+  - Build success, all unit/integration tests pass, no coverage regression, manual smoke test against the compiled binary confirmed discovery/--system-suppression/--no-context-file-suppression all work end-to-end. No new real-credential-verification surface (feature never touches Bedrock directly - reuses Initiative 1's existing system-prompt/cache-point pipeline as-is).
+
+## Unit "agents-md-convention" Status: COMPLETE AND APPROVED (commit c1bb745)
+## INITIATIVE 2 STATUS: COMPLETE (pending final Build and Test approval)

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -445,3 +445,10 @@
 **Context**: INCEPTION PHASE, Initiative 2 - Workspace Detection complete, entering Requirements Analysis
 
 ---
+## Initiative 2 Requirements Analysis Complete
+**Timestamp**: 2026-07-08T15:35:00Z
+**User Input**: Answered clarifying questions directly in chat: "1. Just chat 2. Automatic 3. Overuse wins 4. Skip cursor for now 5. Don't know. Use best judgement"
+**AI Response**: Recorded answers into agents-md-convention-questions.md for the audit trail (interpreting "Overuse wins" as "override wins" - explicit --system/config system-prompt takes precedence entirely; interpreting "use best judgement" on walk-up scope as walk up to the nearest .git boundary, the safest default balancing usefulness against scanning unrelated ancestor directories). Wrote agents-md-convention-requirements.md with FR1-FR6/NFR1-NFR5, incorporating all 5 decisions plus assumptions on the filename precedence list, config key shape, size guard (32KB), disable mechanism, and cache-point synergy reuse from #83.
+**Context**: INCEPTION PHASE, Initiative 2 - Requirements Analysis complete, awaiting approval
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -512,3 +512,21 @@
 **Context**: CONSTRUCTION PHASE, agents-md-convention unit - Code Generation complete, awaiting approval before Build and Test
 
 ---
+## Code Generation - Approval (Initiative 2)
+**Timestamp**: 2026-07-08T16:22:00Z
+**AI Prompt**: "Approve code generation and proceed to Build and Test?"
+**User Response**: "Approved"
+**Status**: Approved
+**Context**: Code generation approved for #88 (commit c1bb745, pushed); Build and Test begins next
+
+---
+
+## Build and Test Complete (Initiative 2)
+**Timestamp**: 2026-07-08T16:25:00Z
+**Build Status**: Success
+**Test Status**: Pass (unit + integration + manual smoke test against the compiled binary; performance/contract N/A)
+**Files Generated**: aidlc-docs/construction/build-and-test/agents-md-convention-summary.md
+**AI Response**: Consolidated the verification already performed during Code Generation Step 14 into the dedicated Build and Test record: make test/lint/test-coverage all pass with no regressions (cmd 23.6%->31.8%, total 66.3%->67.8%), 7/7 integration tests pass, and a manual smoke test against the actual compiled binary (not just unit-test fixtures) confirmed the full chat.go wiring works - discovery from a nested subdirectory correctly walks up to the git boundary, --system suppresses discovery, --no-context-file suppresses discovery. No new real-credential-verification surface since this feature never touches Bedrock directly.
+**Context**: CONSTRUCTION PHASE, agents-md-convention unit - Build and Test complete, awaiting final approval
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -467,3 +467,18 @@
 **Context**: Workflow plan created with 3 stages to execute (Functional Design+NFR, Code Generation, Build and Test) out of 7 possible Inception/Construction stages
 
 ---
+## Workflow Planning - Approval (Initiative 2)
+**Timestamp**: 2026-07-08T15:45:00Z
+**AI Prompt**: "Approve the plan and proceed to Functional Design + NFR?"
+**User Response**: "Approved"
+**Status**: Approved
+**Context**: Execution plan approved for #88; entering Construction phase directly (Application Design and Units Generation both skipped per plan)
+
+---
+
+## Functional Design + NFR Complete (Initiative 2)
+**Timestamp**: 2026-07-08T15:55:00Z
+**AI Response**: Verified design directly against current cmd/chat.go, cmd/systemprompt.go, cmd/config.go source rather than guessing. Resolved the walk-up algorithm into a concrete two-phase design (Phase A: cheap .git-boundary stat-walk, capped at 64 levels defensively; Phase B: check candidates at cwd then boundary dir only, never intermediate levels). Documented 16 business rules covering matching, content handling, config parsing, and the notice. Combined NFR (Security + Reliability only applicable) into one document per Units 2/4 precedent - security posture relies on fixed known filenames within 2 known directories rather than ValidateLocalPath-style traversal defense, since there's no user-supplied path in this feature.
+**Context**: CONSTRUCTION PHASE, agents-md-convention unit - Functional Design + NFR complete, awaiting approval before Code Generation
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -428,3 +428,20 @@
 **User Input**: "Approve and continue"
 **AI Response**: "Approval recorded. This completes the entire Bedrock capability catch-up initiative: INCEPTION (reverse engineering, requirements, user stories, workflow planning, application design, units generation) and CONSTRUCTION (5 units + SDK upgrade prerequisite + build and test) are both done for issues #81-#85. Operations phase remains a placeholder per core-workflow.md - no deployment/monitoring workflow exists or is planned for this project, so there is no further AI-DLC stage to execute. All work is committed and pushed to claude/ai-dlc-documentation-rl4e5s. No PR has been created (not requested) - issues #81-#85 remain open until a PR referencing 'Closes #XX' is merged to the default branch."
 **Context**: INITIATIVE COMPLETE - all INCEPTION and CONSTRUCTION phases done for issues #81-#85
+
+---
+
+## Initiative 1 Epilogue: PR Created, Merged, Issue Cleanup
+**Timestamp**: 2026-07-08T15:10:00Z
+**Events**: PR #97 opened and merged (closing #81-#85). Separately PRs #99/#100/#101 merged to main (release automation, closing #98, unrelated to this initiative). GitHub issue tracker cleanup performed: #96 closed (resolved by #99's ci.yml), #95 closed (resolved - backup file gone, README fixed). Verified #91/#92/#93/#94/#58/#46 still genuinely open on main.
+**Context**: Post-initiative housekeeping, not an AI-DLC stage
+
+---
+
+## Initiative 2 Kickoff: Universal AGENTS.md Convention (#88 redefined)
+**Timestamp**: 2026-07-08T15:20:00Z
+**User Input**: Brainstormed Group 2 (agentic direction) issues #86/#87/#88; chose to redefine #88 from a chat-cli-specific CHATCLI.md idea to a universal AGENTS.md-first convention with fallback to CLAUDE.md/Cursor rules/Copilot instructions/README.md, discussed precedence-not-merge policy, configurable file list, git-root walk-up, size guard, and prompt-cache synergy with #83. User said "Sounds good" to proceed.
+**AI Response**: Updated GitHub issue #88 title/body with the new design. Started AI-DLC for this initiative. Workspace Detection: brownfield, existing aidlc-state.md found, Initiative 1 marked complete. Reverse engineering artifacts stale relative to current main but re-run judged disproportionate to this narrow feature's scope - proceeding directly to Requirements Analysis. Branch claude/ai-dlc-documentation-rl4e5s reset to latest origin/main (d1619d2) since Initiative 1's PR (#97) already merged - starting Initiative 2 fresh per merged-branch restart protocol.
+**Context**: INCEPTION PHASE, Initiative 2 - Workspace Detection complete, entering Requirements Analysis
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -482,3 +482,18 @@
 **Context**: CONSTRUCTION PHASE, agents-md-convention unit - Functional Design + NFR complete, awaiting approval before Code Generation
 
 ---
+## Functional Design + NFR - Approval (Initiative 2)
+**Timestamp**: 2026-07-08T15:58:00Z
+**AI Prompt**: "Approve functional design and proceed to Code Generation?"
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: Functional Design + NFR approved for #88; Code Generation Part 1 (Planning) begins next
+
+---
+
+## Code Generation Plan Created (Initiative 2)
+**Timestamp**: 2026-07-08T16:00:00Z
+**AI Response**: Created a 14-step TDD-ordered plan: 4 pure/near-pure functions in a new cmd/projectcontext.go (resolveContextFilenames, findProjectContextFile, loadProjectContext, resolveAndLoadProjectContext), each preceded by a failing-tests step using t.TempDir() fixtures (no filesystem mocking needed, simpler than Initiative 1's SDK-channel testing); config key wiring (context-files); flag wiring (--no-context-file); chat.go call site; docs; full verification pass.
+**Context**: CONSTRUCTION PHASE, agents-md-convention unit - Code Generation Part 1 (Planning) complete, awaiting approval
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -452,3 +452,18 @@
 **Context**: INCEPTION PHASE, Initiative 2 - Requirements Analysis complete, awaiting approval
 
 ---
+## Requirements Analysis - Approval (Initiative 2)
+**Timestamp**: 2026-07-08T15:40:00Z
+**AI Prompt**: "Approve requirements and proceed to Workflow Planning?"
+**User Response**: "Approve and continue"
+**Status**: Approved (User Stories stage not requested, proceeding as recommended skip)
+**Context**: Requirements approved for #88 (universal AGENTS.md convention); Workflow Planning begins next
+
+---
+
+## Workflow Planning Complete (Initiative 2)
+**Timestamp**: 2026-07-08T15:42:00Z
+**AI Response**: Created execution plan for the AGENTS.md convention feature. Risk assessed Low - isolated, reversible, no infra/data-model/API-contract changes, reuses Initiative 1's system-prompt and cache-point plumbing entirely as-is. Recommends skipping Application Design and Units Generation (single unit, no new subsystem shape, same pattern as Initiative 1's Unit 1). Recommends executing a combined Functional Design + NFR stage (real walk-up/precedence algorithm design plus Security/Reliability NFRs), then Code Generation and Build and Test as always.
+**Context**: Workflow plan created with 3 stages to execute (Functional Design+NFR, Code Generation, Build and Test) out of 7 possible Inception/Construction stages
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -497,3 +497,18 @@
 **Context**: CONSTRUCTION PHASE, agents-md-convention unit - Code Generation Part 1 (Planning) complete, awaiting approval
 
 ---
+## Code Generation Plan - Approval (Initiative 2)
+**Timestamp**: 2026-07-08T16:02:00Z
+**AI Prompt**: "Approve the code generation plan and begin generation?"
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: 14-step plan approved for #88; Code Generation Part 2 (Generation) begins next
+
+---
+
+## Code Generation Complete (Initiative 2)
+**Timestamp**: 2026-07-08T16:20:00Z
+**AI Response**: Executed all 14 steps TDD-ordered (red confirmed via go vet/go test before each implementation). Created cmd/projectcontext.go (7 functions) + cmd/projectcontext_test.go (4 test functions, 19 subtests, t.TempDir() fixtures, no SDK mocking needed). Wired context-files into cmd/config.go, --no-context-file into cmd/root.go, and the discovery call site into cmd/chat.go immediately after the existing systemPrompt resolution. Updated README.md/docs/usage.md. One minor deviation from functional-design.md during implementation: findProjectContextFile gained a third return value (matchedCandidate) to support BR8's skip-and-retry composition in resolveAndLoadProjectContext - documented in code/summary.md. Full verification: make test/lint/test-coverage all pass (cmd 23.6%->31.8%, total 66.3%->67.8%, no regressions), make cli + integration tests 7/7 pass, manual smoke test from a nested subdirectory confirmed the .git-boundary walk-up, --system suppression, and --no-context-file suppression all work end-to-end against the real built binary.
+**Context**: CONSTRUCTION PHASE, agents-md-convention unit - Code Generation complete, awaiting approval before Build and Test
+
+---

--- a/aidlc-docs/construction/agents-md-convention/code/summary.md
+++ b/aidlc-docs/construction/agents-md-convention/code/summary.md
@@ -1,0 +1,24 @@
+# Code Generation Summary: AGENTS.md Convention (#88)
+
+## Files Created
+- `cmd/projectcontext.go` - `defaultContextFilenames`, `resolveContextFilenames`, `findProjectContextFile`, `matchCandidateInDir`, `findGitBoundary`, `loadProjectContext`, `resolveAndLoadProjectContext`, `removeString`
+- `cmd/projectcontext_test.go` - 4 test functions, 19 subtests total, covering BR1-BR13 directly via `t.TempDir()` fixtures (no filesystem mocking needed)
+
+## Files Modified
+- `cmd/config.go` - added `context-files` to `supportedConfigKeys`, the two `Long` help strings, both error-message key lists, and `configListCmd`'s `configKeys` slice
+- `cmd/root.go` - registered `--no-context-file` persistent bool flag (default `false`)
+- `cmd/chat.go` - new call site immediately after the existing `systemPrompt` resolution: reads `--no-context-file` and `context-files`, calls `resolveAndLoadProjectContext` when no explicit system prompt is set, prints the FR6 notice (stdout, gray-styled) or the BR9 truncation warning (stderr)
+- `cmd/cmd_test.go` - added `TestConfigCommandSupportsContextFiles`
+- `integration_test.go` - added `--no-context-file` to `TestCLIFlagsExist`'s expected flag list
+- `README.md`, `docs/usage.md` - new "Project Context" sections
+
+## Design Deviations from Functional Design (minor, during implementation)
+- `findProjectContextFile` gained a third return value, `matchedCandidate string`, not specified in `domain-entities.md`'s original two-value signature. Needed so `resolveAndLoadProjectContext` can implement BR8 (exclude a vacuous/unreadable match and retry the search with the remaining candidates) without re-deriving which candidate string produced a given path.
+- `loadProjectContext`'s `originalSize` is computed from the **raw, untrimmed** file bytes (not the trimmed content), so the BR9 truncation warning reports the actual on-disk size rather than a post-trim figure.
+
+## Test Results
+- `make test`: all packages pass (2 pre-existing `SKIP`s unrelated to this feature)
+- `make lint`: clean
+- `make test-coverage`: `cmd` package 23.6% → 31.8%; total 66.3% → 67.8% (no regression in any package)
+- `go test -tags=integration -v .`: 7/7 pass, including the updated `TestCLIFlagsExist`
+- Manual smoke test (see `build-and-test` artifacts for the full record): `AGENTS.md` placed at a git repo root, `chat-cli` run from a nested subdirectory two levels down - notice printed with the correct resolved path, confirming the Phase A/B walk-up works end-to-end outside the unit-test fixtures. `--system` and `--no-context-file` both confirmed to suppress discovery (no notice printed).

--- a/aidlc-docs/construction/agents-md-convention/functional-design/business-logic-model.md
+++ b/aidlc-docs/construction/agents-md-convention/functional-design/business-logic-model.md
@@ -1,0 +1,58 @@
+# Functional Design: Business Logic Model - AGENTS.md Convention (#88)
+
+## Context
+No Units Generation stage ran for this initiative (single unit, per the execution plan) — this document designs the whole feature directly against `aidlc-docs/inception/requirements/agents-md-convention-requirements.md` (FR1-FR6).
+
+Verified against the actual current codebase (not guessed):
+- `cmd/systemprompt.go` — `buildSystemContentBlocks(systemPrompt string)`, already returns `nil` for an empty string, so anything feeding into it degrades safely.
+- `cmd/chat.go:114` — `systemPrompt := fm.GetConfigValue("system-prompt", systemFlag, "").(string)` is the exact resolution point FR2 hooks into.
+- `cmd/config.go` — `supportedConfigKeys` map and three separate hardcoded key lists (`Long` help text ×2, `configListCmd`'s `configKeys` slice) all need the new `context-files` key added, following the existing (imperfect but established) pattern rather than refactoring it.
+- Gray/dim ANSI styling (`\033[90m...\033[0m`) is already used in `chat.go` for the user-echo line and `[thinking]` prefix — reused for the startup notice (FR6) for visual consistency.
+
+## Core Algorithm: Project-Context Discovery
+
+Resolves FR1.2's "walks up parent directories, stopping at the first directory containing `.git`" into a concrete, two-phase algorithm (rather than checking every intermediate directory level for candidate files, which would mean more filesystem reads for no real benefit):
+
+**Phase A - Locate the search boundary** (cheap: only checks for a `.git` entry's existence, never reads file content):
+1. Start at cwd.
+2. If `.git` exists in the current directory (file or directory — worktrees use a `.git` file), that directory is the boundary. Stop.
+3. Otherwise move to the parent directory and repeat.
+4. If filesystem root is reached with no `.git` found, there is no boundary directory (only cwd itself will be checked in Phase B).
+
+**Phase B - Check for a candidate file**:
+1. Check cwd first: for each filename in the effective precedence list (in order), does a *regular file* (not a directory) with that exact name exist and is it readable? First match wins - stop and use it.
+2. If no match in cwd, and a boundary directory was found in Phase A and it differs from cwd, check the boundary directory the same way (precedence order, first match wins).
+3. If still no match, discovery yields no result. `chat` behaves exactly as it does today (no system prompt).
+
+This means: at most two directories are ever checked for candidate files (cwd and the repo root), regardless of how deep cwd is nested inside the repo. Intermediate directories are only ever probed for `.git`'s existence, never read for content. This satisfies FR1.2 ("walks up ... stopping at ... `.git`") while keeping the search cheap and bounded, and matches the "only cwd is checked" fallback when no repo is detected at all.
+
+## Entry Point and Call Site
+
+- New pure function, `resolveProjectContext(cwd string, candidates []string) (path string, content string, found bool)`, in a new file (see domain-entities.md for the exact file/function shape).
+- Called from `cmd/chat.go`, immediately after the existing line `systemPrompt := fm.GetConfigValue("system-prompt", systemFlag, "").(string)`, **only when**:
+  - `systemPrompt == ""` (neither `--system` nor configured `system-prompt` supplied anything - FR2.1), **and**
+  - the new `--no-context-file` flag is `false` (FR5.1), **and**
+  - the effective `context-files` candidate list (FR4.1, default or config-overridden) is non-empty (FR5.2).
+- On a match, `systemPrompt` is reassigned to the file's (possibly truncated) content, and the FR6 notice is printed. Everything downstream (`buildSystemContentBlocks`, `withSystemCachePoint`) is completely unchanged — it already treats whatever string it's given as "the system prompt," with no knowledge of where it came from.
+- `cmd/prompt.go` is untouched (chat-only scope, decision 1).
+
+## Data Flow
+
+```
+cwd, --no-context-file, context-files config
+        |
+        v
+[effective candidate list resolved: config value if set, else default 3-name list]
+        |
+        v
+[Phase A: walk up from cwd, stat-only, find .git boundary or none]
+        |
+        v
+[Phase B: check cwd, then boundary dir, for first matching filename]
+        |
+        v
+[no match] -> systemPrompt stays "" (today's behavior, unchanged)
+[match]    -> read file -> trim -> truncate at 32KB with stderr warning if needed
+              -> if resulting content is non-empty after trim: systemPrompt = content,
+                 print FR6 notice; else: treat as no match (vacuous file), systemPrompt stays ""
+```

--- a/aidlc-docs/construction/agents-md-convention/functional-design/business-rules.md
+++ b/aidlc-docs/construction/agents-md-convention/functional-design/business-rules.md
@@ -1,0 +1,29 @@
+# Functional Design: Business Rules - AGENTS.md Convention (#88)
+
+## Precedence and Matching Rules
+- **BR1**: Filename matching is exact-case (`AGENTS.md`, not `agents.md`/`Agents.md`), per Assumption 6 in requirements.md.
+- **BR2**: A candidate name must resolve to a *regular file*. A directory or other non-regular entry (symlink to a directory, device file, etc.) with a matching name is not a match - move to the next candidate. A symlink to a regular file IS a valid match (normal file-read semantics, no special-casing - this is a local convenience file a user placed themselves, not untrusted input from a tool call).
+- **BR3**: Within a checked directory, the first filename in precedence order that matches wins - remaining candidates at that directory level are not checked.
+- **BR4**: cwd is checked before the repo-root boundary directory. If cwd itself IS the repo root (has `.git` directly), only one directory is checked (no duplicate check).
+- **BR5**: The default precedence list is `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md` (requirements.md Assumption 1). `.github/copilot-instructions.md` is a relative path (one path segment with a directory component) - matching for this candidate means "does `<checked-dir>/.github/copilot-instructions.md` exist as a regular file," same file-existence rule as the flat filenames.
+
+## Precedence vs. Explicit System Prompt (FR2)
+- **BR6**: If `--system` is passed with any value (including a value that happens to be an empty string via `--system ""`), OR a `system-prompt` config value is set, discovery is never attempted. This is decided once, before Phase A/B run at all - no wasted filesystem work when it's going to be discarded anyway.
+
+## Content Handling
+- **BR7**: File content is read as raw bytes, decoded as UTF-8, then whitespace-trimmed (leading and trailing) before any further processing.
+- **BR8**: If content is empty after trimming (BR7) - whether the file was truly empty or contained only whitespace - it is treated as **no match** and the search rule in BR3/BR4 (move to next candidate, then next directory) continues to apply, rather than "found but empty." Rationale: a vacuous file shouldn't silently produce a no-op FR6 notice, and it costs nothing extra to keep checking the remaining candidates.
+- **BR9**: Content longer than 32KB (after trimming) is truncated to exactly 32KB, and a one-line warning is printed to **stderr** (not stdout - FR3.2) identifying the truncated file's path and original size, before the (truncated) content is used as the system prompt.
+- **BR10**: A file that exists but can't be read (permission error, race condition where it's deleted between stat and read, etc.) is treated as **no match** per NFR4 - the search continues exactly as if the file didn't exist. This is never a fatal error for `chat` to start.
+
+## Configuration Rules (FR4)
+- **BR11**: `context-files` config value, when set, is parsed as a comma-separated list. Each entry is whitespace-trimmed; empty entries (from `,,` or leading/trailing commas) are dropped.
+- **BR12**: If `context-files` is set to an empty string (`chat-cli config set context-files ""`) or a value that trims down to zero entries after BR11, the effective candidate list is empty - this is precisely FR5.2's disable-via-config mechanism, not an error.
+- **BR13**: If `context-files` is unset entirely, the default 3-name list (BR5) is used.
+
+## Disabling (FR5)
+- **BR14**: `--no-context-file` (a session-scoped flag, not persisted) always wins over any config state - if passed, discovery is skipped unconditionally, even if `context-files` is configured with a non-empty list.
+
+## Notice (FR6)
+- **BR15**: The notice is only printed when a match was actually used (i.e., content was non-empty after BR8's check) - never printed for the "no match" or "disabled" cases, since there's nothing to announce.
+- **BR16**: The notice shows the path exactly as resolved (e.g. `AGENTS.md` if found in cwd, or a relative-to-cwd path like `../AGENTS.md` if found at the repo-root boundary instead) so the user can tell which of the two checked locations supplied it.

--- a/aidlc-docs/construction/agents-md-convention/functional-design/domain-entities.md
+++ b/aidlc-docs/construction/agents-md-convention/functional-design/domain-entities.md
@@ -1,0 +1,37 @@
+# Functional Design: Domain Entities - AGENTS.md Convention (#88)
+
+This feature has no persistent data model (no DB schema change, no new persisted entity) - "entities" here means the new pure-function surface and its inputs/outputs, following the same style as Initiative 1's `cmd/systemprompt.go`/`cmd/promptcache.go`.
+
+## New File: `cmd/projectcontext.go`
+
+Mirrors the existing single-purpose file-per-feature pattern (`systemprompt.go`, `promptcache.go`, `documentinput.go`, `reasoning.go`).
+
+### `defaultContextFilenames`
+A package-level `[]string{"AGENTS.md", "CLAUDE.md", ".github/copilot-instructions.md"}` - the BR5 default precedence list, used when the `context-files` config key is unset.
+
+### `resolveContextFilenames(configValue string) []string`
+Implements BR11-BR13: parses the comma-separated config value (trim, drop empties); returns `defaultContextFilenames` if the config value is empty/unset, otherwise the parsed list (which may itself be empty, per BR12 - the disable case).
+
+### `findProjectContextFile(cwd string, candidates []string) (path string, ok bool)`
+Implements the Phase A boundary walk + Phase B check from business-logic-model.md and BR1-BR4. Pure with respect to its inputs (`cwd`, `candidates`) but does touch the filesystem (`os.Stat`) - this is the one function that needs a temp-directory fixture in tests rather than being a fully pure computation, same testing shape as `utils.ValidateLocalPath` already has.
+
+### `loadProjectContext(path string) (content string, truncated bool, originalSize int, err error)`
+Implements BR7-BR10: reads the file, trims whitespace, truncates at 32KB if needed. Returns enough information for the caller to print the FR6 notice and the BR9 truncation warning without re-deriving anything. A read error (BR10) is returned as `err` for the caller to treat as "no match" - this function does not itself decide search-continuation policy, that's the caller's (`resolveAndLoadProjectContext`, below) job.
+
+### `resolveAndLoadProjectContext(cwd string, candidates []string) (content string, sourcePath string, truncated bool, found bool)`
+Composition root tying the above three together, plus BR8's "empty-after-trim counts as no match, keep searching" loop. This is the one function `cmd/chat.go` actually calls.
+
+## `cmd/chat.go` Changes
+- New flag: `--no-context-file` (bool, default `false`) - registered as a persistent flag alongside the existing `--tools`/`--thinking` flags in `cmd/root.go`'s `init()` (same file that already registers all other chat/prompt-shared flags).
+- New call site immediately after the existing `systemPrompt := fm.GetConfigValue(...)` line (chat.go:114), gated per business-logic-model.md's "Entry Point and Call Site" conditions.
+- New notice print (FR6/BR15/BR16), styled `\033[90m...\033[0m` matching the existing gray convention.
+
+## `cmd/config.go` Changes
+- `supportedConfigKeys["context-files"] = true`
+- `configSetCmd`/`configUnsetCmd`'s `Long` help text and error-message key lists updated to mention `context-files` (matching the existing pattern where these are hand-maintained alongside the map - not refactored into a single source of truth here, out of scope for this feature).
+- `configListCmd`'s hardcoded `configKeys` slice gains `"context-files"`.
+
+## No Changes Needed
+- `cmd/systemprompt.go`, `cmd/promptcache.go` - both consume "the resolved system prompt string" with no awareness of its source; reused completely as-is (FR3.1, FR3.3).
+- `cmd/prompt.go` - out of scope, chat-only (decision 1).
+- `db`/`repository` packages - no persistence changes.

--- a/aidlc-docs/construction/agents-md-convention/nfr-requirements/nfr-requirements-and-design.md
+++ b/aidlc-docs/construction/agents-md-convention/nfr-requirements/nfr-requirements-and-design.md
@@ -1,0 +1,37 @@
+# NFR Requirements and Design (Combined): AGENTS.md Convention (#88)
+
+Combined into one document, same as Units 2 and 4 in Initiative 1, given the narrow NFR profile of a single-user local CLI - Security and Reliability are the only applicable categories. Scalability/Performance/Availability are N/A for the same reasons documented throughout Initiative 1 (see `aidlc-docs/construction/build-and-test/performance-test-instructions.md`): no concurrent load, no throughput target, single local process.
+
+## Security
+
+### Requirement
+File discovery must never read content outside the two directories the user is already implicitly trusting: their current working directory, and the root of the git repository they're standing inside. It must not be usable to read arbitrary files elsewhere on the filesystem, and it must not silently scan an unbounded number of ancestor directories.
+
+### Design
+- **Bounded to exactly two directories** (business-logic-model.md's Phase A/B): cwd and, if found, the git-root boundary. No other directory's contents are ever enumerated or read.
+- **Phase A only ever checks for `.git`'s existence** (a stat call, not a content read) while walking upward - this walk is bounded by the filesystem's actual depth (or, defensively, capped - see Design Note below) and never reads file *content* outside the two Phase B directories.
+- **Fixed, known filenames only** - unlike `--document`/`read_file` (Initiative 1, Units 2/4) which take a user- or model-supplied path and need `utils.ValidateLocalPath`'s path-traversal defenses, this feature only ever checks for exact, hardcoded (or explicitly user-configured via `context-files`) filenames within the two known directories. There is no user-supplied *path* to validate - the attack surface `ValidateLocalPath` defends against (`../../etc/passwd`-style traversal) doesn't apply here, since candidates are filenames/relative-subpaths joined against a directory chat-cli itself determined, never a raw external input path.
+- **Design Note - walk-up cap**: Phase A's upward walk is theoretically unbounded if `chat` is run from a very deeply nested cwd with no `.git` anywhere above it (e.g. accidentally run from `/`). Cap the walk at a generous fixed depth (e.g. 64 levels) as a defensive belt-and-suspenders measure against pathological input, even though in practice this only costs cheap `stat` calls, never file reads.
+- **Local, self-authored content**: unlike tool-call results or model output, the file content here is something the user (or their team) wrote directly into their own repository - there's no untrusted-input/prompt-injection concern analogous to Unit 4's document-name sanitization, since this isn't material being described *to* Bedrock as coming from an external document, it's used exactly like an explicit `--system` value already is today.
+
+### Compliance
+✅ Compliant - bounded directory scope, no traversal surface, no untrusted-content handling gap.
+
+## Reliability
+
+### Requirement
+A missing, unreadable, empty, or oddly-permissioned candidate file must never prevent `chat` from starting. Discovery is a nice-to-have convenience, not a hard dependency.
+
+### Design
+- BR10: a read error (permission denied, race-condition deletion, etc.) is treated as "no match," search continues to the next candidate - never a fatal error, never even a warning (this is expected/silent, since e.g. checking for `CLAUDE.md` in a repo that doesn't have one is the overwhelmingly common case).
+- BR8: an empty-after-trim file is likewise treated as "no match," not as "found but empty" - avoids a confusing FR6 notice for a file that contributes nothing.
+- The one place this feature *can* affect startup is the flag-parsing/config-read calls it adds (`--no-context-file`, `context-files`) - these follow the exact same `log.Fatalf` pattern already used for every other flag in `chat.go` today (a genuinely malformed flag value is a usage error, consistent with existing behavior, not a new failure mode).
+
+### Compliance
+✅ Compliant - filesystem-level failures degrade to "no match," never fatal; flag/config errors use the codebase's existing, already-accepted error-handling convention.
+
+## Non-Applicable Categories
+- **Scalability**: N/A - single local process, no concurrent users.
+- **Performance**: N/A beyond "runs once at `chat` startup, bounded to ≤2 directory checks + a capped upward stat-walk" - no load/throughput concept, consistent with `performance-test-instructions.md`'s established rationale for this whole project.
+- **Availability**: N/A - no uptime/SLA concept for a local CLI.
+- **Maintainability**: Addressed structurally (one new file following the established per-feature-file convention) rather than as a distinct NFR requiring its own analysis.

--- a/aidlc-docs/construction/build-and-test/agents-md-convention-summary.md
+++ b/aidlc-docs/construction/build-and-test/agents-md-convention-summary.md
@@ -1,0 +1,43 @@
+# Build and Test Summary: AGENTS.md Convention (#88)
+
+Single-unit initiative - the verification below was already executed once during Code Generation Step 14 and is re-confirmed/consolidated here as the dedicated Build and Test record, per core-workflow.md.
+
+## Build
+- **Build Tool**: Go 1.24+ (`go build`/`make cli`)
+- **Status**: ✅ Success - `go build ./...` clean, no warnings
+- **Artifacts**: `./bin/chat-cli` (built, smoke-tested, then removed - gitignored, not committed)
+
+## Unit Tests
+- **New test functions**: `TestResolveContextFilenames`, `TestFindProjectContextFile`, `TestLoadProjectContext`, `TestResolveAndLoadProjectContext` (19 subtests total, `cmd/projectcontext_test.go`), plus `TestConfigCommandSupportsContextFiles` (`cmd/cmd_test.go`)
+- **Command**: `make test` (`go test ./... -v`)
+- **Result**: ✅ All packages pass. 2 pre-existing `SKIP`s (`TestBubbleInput`/`TestStringPrompt`, unrelated to this feature - require live TTY).
+- **Coverage**: `cmd` package 23.6% → 31.8%; total 66.3% → 67.8%. No package regressed.
+- **Lint**: `make lint` - clean (`go vet` + `go fmt`).
+
+## Integration Tests
+- **Command**: `make cli && go test -tags=integration -v .`
+- **Result**: ✅ 7/7 pass, including `TestCLIFlagsExist` (updated to assert `--no-context-file` is present in `--help` output).
+
+## Manual Smoke Test (against the real built binary, not just unit-test fixtures)
+Set up a temp git repo with `AGENTS.md` at the root, ran `chat-cli` from a subdirectory two levels down:
+
+| Scenario | Command | Result |
+|---|---|---|
+| Discovery walks up to the git boundary and loads the file | `chat-cli` (from `repo/sub/`) | ✅ `Using project context: <repo>/AGENTS.md` printed, session started with that content as the system prompt |
+| Explicit `--system` suppresses discovery entirely | `chat-cli --system "explicit override"` | ✅ No notice printed |
+| `--no-context-file` suppresses discovery | `chat-cli --no-context-file` | ✅ No notice printed |
+
+This is the one thing the unit tests (which construct `cwd`/candidates directly) couldn't confirm on their own: that the flag-reading, config-reading, and `os.Getwd()`-based call site in `cmd/chat.go` are actually wired together correctly end-to-end in the compiled binary.
+
+## Performance / Contract / Security Tests
+- **Performance**: N/A - same rationale as Initiative 1 (single local process, no load concept). Discovery runs once at `chat` startup, bounded to ≤2 directory checks plus a capped upward stat-walk (`nfr-requirements-and-design.md`).
+- **Contract**: N/A - no service-to-service contracts.
+- **Security**: Covered inline via the NFR design (`aidlc-docs/construction/agents-md-convention/nfr-requirements/nfr-requirements-and-design.md`) rather than a separate scan - bounded to 2 known directories, fixed known filenames only, no user-supplied path/traversal surface.
+
+## What Still Needs Real-Credential Verification
+Nothing new from this feature - it never touches Bedrock. The loaded content flows into the exact same `SystemContentBlocks`/cache-point pipeline Initiative 1 already built and (per that initiative's own build-and-test-summary.md) still has its own outstanding real-credential verification items. This feature adds no new unverified-against-a-live-model surface.
+
+## Overall Status
+- **Build**: ✅ Success
+- **All Tests**: ✅ Pass (unit + integration + manual smoke test; performance/contract N/A)
+- **Ready for**: Merge. #88 will close automatically once a PR referencing it merges to `main`.

--- a/aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md
@@ -9,44 +9,44 @@
 
 ## Steps
 
-- [ ] **Step 1 - Failing tests: `resolveContextFilenames`**
+- [x] **Step 1 - Failing tests: `resolveContextFilenames`**
   Create `cmd/projectcontext_test.go` with cases for BR11-BR13: unset config → default 3-name list; custom CSV → parsed/trimmed list; empty entries dropped (`"AGENTS.md,,CLAUDE.md"`); explicit `""` → empty list (disable case). Run `go test ./cmd/... -run TestResolveContextFilenames` and confirm it fails to compile (function doesn't exist yet).
 
-- [ ] **Step 2 - Implement `resolveContextFilenames`**
+- [x] **Step 2 - Implement `resolveContextFilenames`**
   Create `cmd/projectcontext.go` with `defaultContextFilenames` and `resolveContextFilenames(configValue string) []string`. Run the Step 1 tests, confirm green.
 
-- [ ] **Step 3 - Failing tests: `findProjectContextFile`**
+- [x] **Step 3 - Failing tests: `findProjectContextFile`**
   Add cases using `t.TempDir()` fixtures for BR1-BR4 + the Phase A/B algorithm: match in cwd; no match in cwd but match at a `.git`-boundary parent; no match anywhere; a directory named `AGENTS.md` is not treated as a match (BR2); cwd match takes precedence even when a boundary match also exists (BR4); no `.git` anywhere → only cwd checked. Confirm compile failure.
 
-- [ ] **Step 4 - Implement `findProjectContextFile`**
+- [x] **Step 4 - Implement `findProjectContextFile`**
   Implement Phase A (upward `.git`-existence walk, capped at 64 levels per the NFR design note) and Phase B (check candidates at cwd, then the boundary dir if different) in `cmd/projectcontext.go`. Run Step 3 tests, confirm green.
 
-- [ ] **Step 5 - Failing tests: `loadProjectContext`**
+- [x] **Step 5 - Failing tests: `loadProjectContext`**
   Add cases for BR7-BR10: normal read + trim; content over 32KB → truncated to exactly 32KB with `truncated=true`/correct `originalSize`; content under 32KB → `truncated=false`; unreadable file (e.g. no read permission, or a path to a directory) → returns an error. Confirm compile failure.
 
-- [ ] **Step 6 - Implement `loadProjectContext`**
+- [x] **Step 6 - Implement `loadProjectContext`**
   Implement read + trim + 32KB truncation in `cmd/projectcontext.go`. Run Step 5 tests, confirm green.
 
-- [ ] **Step 7 - Failing tests: `resolveAndLoadProjectContext`**
+- [x] **Step 7 - Failing tests: `resolveAndLoadProjectContext`**
   Add composition-level cases: full pipeline finds and loads a match; BR8's empty-after-trim file is skipped and search continues to the next candidate; no candidates match anywhere → `found=false`; multiple candidates present → precedence order (BR3) respected end-to-end. Confirm compile failure.
 
-- [ ] **Step 8 - Implement `resolveAndLoadProjectContext`**
+- [x] **Step 8 - Implement `resolveAndLoadProjectContext`**
   Wire `resolveContextFilenames` (only needed by the caller, not this function - takes `candidates []string` directly per domain-entities.md) → `findProjectContextFile` → `loadProjectContext`, with the BR8 skip-and-continue loop. Run Step 7 tests, confirm green.
 
-- [ ] **Step 9 - `context-files` config key**
+- [x] **Step 9 - `context-files` config key**
   In `cmd/config.go`: add `"context-files": true` to `supportedConfigKeys`; update the `Long` help text on `configSetCmd`/`configUnsetCmd` and the error-message key lists; add `"context-files"` to `configListCmd`'s `configKeys` slice. Extend `cmd/config_test.go` if it asserts against the supported-keys set (check first), otherwise add a minimal case confirming `context-files` is accepted by `config set`.
 
-- [ ] **Step 10 - `--no-context-file` flag**
+- [x] **Step 10 - `--no-context-file` flag**
   Register a persistent bool flag `--no-context-file` (default `false`) in `cmd/root.go`'s `init()`, alongside the existing `--tools`/`--thinking` registrations. Update `TestCLIFlagsExist` in `integration_test.go` to assert the new flag is present (grep-style check, matching how the other Initiative-1 flags were added to that test).
 
-- [ ] **Step 11 - Wire into `cmd/chat.go`**
+- [x] **Step 11 - Wire into `cmd/chat.go`**
   Immediately after the existing `systemPrompt := fm.GetConfigValue("system-prompt", systemFlag, "").(string)` line: read the `--no-context-file` flag and the `context-files` config value; if `systemPrompt == ""` and the flag is false and `resolveContextFilenames(...)` yields a non-empty list, call `resolveAndLoadProjectContext(cwd, candidates)` (cwd via `os.Getwd()`). On a truncation, print the BR9 warning to stderr. On a found match, assign `systemPrompt` to the loaded content and print the FR6/BR15/BR16 notice to stdout using the existing `\033[90m...\033[0m` gray styling convention already used elsewhere in this file.
 
-- [ ] **Step 12 - Unit tests for the `chat.go` call site**
+- [x] **Step 12 - Unit tests for the `chat.go` call site**
   Since `chat.go`'s `RunE` isn't unit-tested directly today (established precedent - CLI wiring is covered by integration tests, not unit tests), verify this step by re-running the full suite plus a manual smoke test in Step 14, rather than adding a new brittle unit test around Cobra command execution.
 
-- [ ] **Step 13 - Documentation**
+- [x] **Step 13 - Documentation**
   Update `README.md` and `docs/usage.md` with a new "Project Context" section: what `AGENTS.md`/`CLAUDE.md`/`.github/copilot-instructions.md` do, the precedence rule, `context-files` config, `--no-context-file`, and the chat-only scope.
 
-- [ ] **Step 14 - Full verification**
+- [x] **Step 14 - Full verification**
   `make test`, `make lint`, `make test-coverage` (confirm no regression), `make cli && go test -tags=integration -v .`. Manual smoke test: run `chat-cli` from a directory containing an `AGENTS.md`, confirm the notice prints and the system prompt is used; confirm `--system` suppresses discovery; confirm `--no-context-file` suppresses discovery.

--- a/aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/agents-md-convention-code-generation-plan.md
@@ -1,0 +1,52 @@
+# Code Generation Plan: AGENTS.md Convention (#88)
+
+## Unit Context
+- **Stories/Requirements**: FR1-FR6, NFR1-NFR5 from `aidlc-docs/inception/requirements/agents-md-convention-requirements.md`
+- **Design source**: `aidlc-docs/construction/agents-md-convention/functional-design/` + `nfr-requirements/nfr-requirements-and-design.md`
+- **Dependencies**: Reuses `cmd/systemprompt.go` (`buildSystemContentBlocks`) and `cmd/promptcache.go` (`withSystemCachePoint`) as-is, no changes to either. Scope is `chat` only (`cmd/prompt.go` untouched).
+- **Workspace root**: `/home/user/chat-cli` (per `aidlc-docs/aidlc-state.md`)
+- **Project type**: Brownfield, Go module, existing `cmd/` package structure - all new code goes in `cmd/` alongside the Initiative 1 precedent files.
+
+## Steps
+
+- [ ] **Step 1 - Failing tests: `resolveContextFilenames`**
+  Create `cmd/projectcontext_test.go` with cases for BR11-BR13: unset config → default 3-name list; custom CSV → parsed/trimmed list; empty entries dropped (`"AGENTS.md,,CLAUDE.md"`); explicit `""` → empty list (disable case). Run `go test ./cmd/... -run TestResolveContextFilenames` and confirm it fails to compile (function doesn't exist yet).
+
+- [ ] **Step 2 - Implement `resolveContextFilenames`**
+  Create `cmd/projectcontext.go` with `defaultContextFilenames` and `resolveContextFilenames(configValue string) []string`. Run the Step 1 tests, confirm green.
+
+- [ ] **Step 3 - Failing tests: `findProjectContextFile`**
+  Add cases using `t.TempDir()` fixtures for BR1-BR4 + the Phase A/B algorithm: match in cwd; no match in cwd but match at a `.git`-boundary parent; no match anywhere; a directory named `AGENTS.md` is not treated as a match (BR2); cwd match takes precedence even when a boundary match also exists (BR4); no `.git` anywhere → only cwd checked. Confirm compile failure.
+
+- [ ] **Step 4 - Implement `findProjectContextFile`**
+  Implement Phase A (upward `.git`-existence walk, capped at 64 levels per the NFR design note) and Phase B (check candidates at cwd, then the boundary dir if different) in `cmd/projectcontext.go`. Run Step 3 tests, confirm green.
+
+- [ ] **Step 5 - Failing tests: `loadProjectContext`**
+  Add cases for BR7-BR10: normal read + trim; content over 32KB → truncated to exactly 32KB with `truncated=true`/correct `originalSize`; content under 32KB → `truncated=false`; unreadable file (e.g. no read permission, or a path to a directory) → returns an error. Confirm compile failure.
+
+- [ ] **Step 6 - Implement `loadProjectContext`**
+  Implement read + trim + 32KB truncation in `cmd/projectcontext.go`. Run Step 5 tests, confirm green.
+
+- [ ] **Step 7 - Failing tests: `resolveAndLoadProjectContext`**
+  Add composition-level cases: full pipeline finds and loads a match; BR8's empty-after-trim file is skipped and search continues to the next candidate; no candidates match anywhere → `found=false`; multiple candidates present → precedence order (BR3) respected end-to-end. Confirm compile failure.
+
+- [ ] **Step 8 - Implement `resolveAndLoadProjectContext`**
+  Wire `resolveContextFilenames` (only needed by the caller, not this function - takes `candidates []string` directly per domain-entities.md) → `findProjectContextFile` → `loadProjectContext`, with the BR8 skip-and-continue loop. Run Step 7 tests, confirm green.
+
+- [ ] **Step 9 - `context-files` config key**
+  In `cmd/config.go`: add `"context-files": true` to `supportedConfigKeys`; update the `Long` help text on `configSetCmd`/`configUnsetCmd` and the error-message key lists; add `"context-files"` to `configListCmd`'s `configKeys` slice. Extend `cmd/config_test.go` if it asserts against the supported-keys set (check first), otherwise add a minimal case confirming `context-files` is accepted by `config set`.
+
+- [ ] **Step 10 - `--no-context-file` flag**
+  Register a persistent bool flag `--no-context-file` (default `false`) in `cmd/root.go`'s `init()`, alongside the existing `--tools`/`--thinking` registrations. Update `TestCLIFlagsExist` in `integration_test.go` to assert the new flag is present (grep-style check, matching how the other Initiative-1 flags were added to that test).
+
+- [ ] **Step 11 - Wire into `cmd/chat.go`**
+  Immediately after the existing `systemPrompt := fm.GetConfigValue("system-prompt", systemFlag, "").(string)` line: read the `--no-context-file` flag and the `context-files` config value; if `systemPrompt == ""` and the flag is false and `resolveContextFilenames(...)` yields a non-empty list, call `resolveAndLoadProjectContext(cwd, candidates)` (cwd via `os.Getwd()`). On a truncation, print the BR9 warning to stderr. On a found match, assign `systemPrompt` to the loaded content and print the FR6/BR15/BR16 notice to stdout using the existing `\033[90m...\033[0m` gray styling convention already used elsewhere in this file.
+
+- [ ] **Step 12 - Unit tests for the `chat.go` call site**
+  Since `chat.go`'s `RunE` isn't unit-tested directly today (established precedent - CLI wiring is covered by integration tests, not unit tests), verify this step by re-running the full suite plus a manual smoke test in Step 14, rather than adding a new brittle unit test around Cobra command execution.
+
+- [ ] **Step 13 - Documentation**
+  Update `README.md` and `docs/usage.md` with a new "Project Context" section: what `AGENTS.md`/`CLAUDE.md`/`.github/copilot-instructions.md` do, the precedence rule, `context-files` config, `--no-context-file`, and the chat-only scope.
+
+- [ ] **Step 14 - Full verification**
+  `make test`, `make lint`, `make test-coverage` (confirm no regression), `make cli && go test -tags=integration -v .`. Manual smoke test: run `chat-cli` from a directory containing an `AGENTS.md`, confirm the notice prints and the system prompt is used; confirm `--system` suppresses discovery; confirm `--no-context-file` suppresses discovery.

--- a/aidlc-docs/inception/plans/agents-md-convention-execution-plan.md
+++ b/aidlc-docs/inception/plans/agents-md-convention-execution-plan.md
@@ -1,0 +1,105 @@
+# Execution Plan: Universal Project-Context File Convention (#88)
+
+## Detailed Analysis Summary
+
+### Transformation Scope (Brownfield)
+- **Transformation Type**: Single component change - new file-discovery/loading logic feeding into the existing system-prompt pipeline built in Initiative 1 (#81)
+- **Primary Changes**: New discovery logic (precedence list, directory walk-up to `.git` boundary, size-guarded read), a new `context-files` config key, a `--no-context-file` flag, and a one-line startup notice in `chat`
+- **Related Components**: `cmd/systemprompt.go` (reused as-is - the loaded content flows into the existing `buildSystemContentBlocks`), `cmd/chat.go` (new call site at startup, before the existing system-prompt resolution short-circuits), `cmd/config.go` (`supportedConfigKeys` gains `context-files`), `cmd/promptcache.go` (reused as-is - no changes needed, caching already applies to whatever ends up in the system prompt)
+
+### Change Impact Assessment
+- **User-facing changes**: Yes - `chat` sessions in a repo containing an `AGENTS.md`/`CLAUDE.md`/`.github/copilot-instructions.md` will now get a system prompt automatically where none existed before. This is the one meaningfully new behavior (everything else in Initiative 1 was purely opt-in via a flag); mitigated by the startup notice (FR6) and the disable flag (FR5).
+- **Structural changes**: No - no new package, no new subsystem shape; this is a new pure-function file plus one new call site, following the exact precedent of `cmd/systemprompt.go`/`cmd/promptcache.go`/`cmd/documentinput.go`/`cmd/reasoning.go` from Initiative 1.
+- **Data model changes**: No - no schema, no persistence changes.
+- **API changes**: No - no new Bedrock API surface. Reuses `SystemContentBlocks` and cache-point plumbing already built and tested in Initiative 1.
+- **NFR impact**: Yes - security (bounded, read-only directory walk-up; must not escape upward past the repo root or read unintended files) and reliability (missing/unreadable files must degrade to "no match", never a fatal error).
+
+### Component Relationships (Brownfield)
+- **Primary Component**: New `cmd/projectcontext.go` (name to be finalized in Functional Design)
+- **Consuming Component**: `cmd/chat.go` - the only call site, per the chat-only scope decision
+- **Shared Components Reused As-Is**: `cmd/systemprompt.go` (`buildSystemContentBlocks`), `cmd/promptcache.go` (`withSystemCachePoint`), `cmd/config.go` (`supportedConfigKeys` pattern)
+- **Dependent Components**: None - nothing else in the codebase calls into this new logic
+- **Supporting Components**: None (no infra, no CI changes needed beyond the existing `ci.yml` already running `make test`/`make lint`/integration tests on every PR)
+
+### Risk Assessment
+- **Risk Level**: Low - isolated to one new file plus one new call site in an already-well-tested command; trivially reversible (revert the commit, or use the new disable flag); no infrastructure, no data model, no external API surface changes
+- **Rollback Complexity**: Easy
+- **Testing Complexity**: Simple - pure functions (precedence matching, walk-up-to-`.git`, truncation) are directly unit-testable with a temp-directory fixture, no SDK mocking needed at all (unlike Initiative 1's tool-use/streaming work)
+
+## Workflow Visualization
+
+```mermaid
+flowchart TD
+    Start(["User Request: AGENTS.md convention"])
+
+    subgraph INCEPTION["🔵 INCEPTION PHASE"]
+        WD["Workspace Detection<br/><b>COMPLETED</b>"]
+        RA["Requirements Analysis<br/><b>COMPLETED</b>"]
+        US["User Stories<br/><b>SKIP</b>"]
+        WP["Workflow Planning<br/><b>COMPLETED</b>"]
+        AD["Application Design<br/><b>SKIP</b>"]
+        UG["Units Generation<br/><b>SKIP</b>"]
+    end
+
+    subgraph CONSTRUCTION["🟢 CONSTRUCTION PHASE"]
+        FD["Functional Design + NFR<br/>(combined)<br/><b>EXECUTE</b>"]
+        ID["Infrastructure Design<br/><b>SKIP</b>"]
+        CG["Code Generation<br/><b>EXECUTE</b>"]
+        BT["Build and Test<br/><b>EXECUTE</b>"]
+    end
+
+    subgraph OPERATIONS["🟡 OPERATIONS PHASE"]
+        OPS["Operations<br/><b>PLACEHOLDER</b>"]
+    end
+
+    Start --> WD --> RA --> US --> WP --> AD --> UG --> FD --> ID --> CG --> BT --> OPS --> End(["Complete"])
+
+    style WD fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style RA fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style WP fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style US fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style AD fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style UG fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style FD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style ID fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style CG fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style BT fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style OPS fill:#FFF59D,stroke:#F9A825,stroke-width:2px,color:#000
+    style Start fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+    style End fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+
+    linkStyle default stroke:#333,stroke-width:2px
+```
+
+## Phases to Execute
+
+### 🔵 INCEPTION PHASE
+- [x] Workspace Detection (COMPLETED)
+- [x] Requirements Analysis (COMPLETED)
+- [ ] User Stories - **SKIP**
+  - **Rationale**: Single cohesive feature, one persona already established in Initiative 1, requirements already concrete at the FR level (FR1-FR6) with no acceptance-criteria ambiguity that stories would resolve.
+- [x] Workflow Planning (this document)
+- [ ] Application Design - **SKIP**
+  - **Rationale**: No new component/subsystem shape - this is a pure-function addition following the exact established pattern of `cmd/systemprompt.go`/`cmd/promptcache.go`/`cmd/documentinput.go`, all of which also skipped Application Design in Initiative 1. No new services, no component-method contracts to define beyond what Functional Design will pin down directly.
+- [ ] Units Generation - **SKIP**
+  - **Rationale**: Naturally one unit of work; no parallelization benefit; straightforward implementation (file precedence matching + directory walk-up + config key), same category as Initiative 1's Unit 1 (System Prompt).
+
+### 🟢 CONSTRUCTION PHASE
+- [ ] Functional Design + NFR Requirements/Design - **EXECUTE (combined)**
+  - **Rationale**: While there's no new Bedrock SDK surface to verify (unlike most of Initiative 1), there is real algorithmic design to pin down before writing tests: the exact walk-up-to-`.git` traversal, precedence-matching order, truncation behavior, and the interaction between `--no-context-file`/config/`--system` precedence. Combined with NFR since the only applicable NFR category is Security (bounded directory walk) plus Reliability (graceful degradation on missing/unreadable files) - same combined-presentation pattern used for Units 2 and 4 in Initiative 1.
+  - Infrastructure Design sub-step - **SKIP**: No infrastructure in this project (decided globally in Initiative 1, still holds).
+- [ ] Code Generation - **EXECUTE (ALWAYS)**
+- [ ] Build and Test - **EXECUTE (ALWAYS)**
+
+### 🟡 OPERATIONS PHASE
+- [ ] Operations - **PLACEHOLDER** (no deployment/monitoring workflow exists or is planned for this project)
+
+## Estimated Timeline
+- **Total Stages Executing**: 3 (Functional Design+NFR, Code Generation, Build and Test) out of 7 possible Inception/Construction stages
+- **Estimated Duration**: Single session, comparable to Initiative 1's Unit 1 or Unit 4 in scope
+
+## Success Criteria
+- **Primary Goal**: `chat` automatically picks up project context from `AGENTS.md`/`CLAUDE.md`/`.github/copilot-instructions.md` without breaking any existing behavior
+- **Key Deliverables**: New discovery/loading logic, `context-files` config key, `--no-context-file` flag, startup notice, full test coverage, updated docs
+- **Quality Gates**: `make test`, `make lint`, `make test-coverage` (no regression), `go test -tags=integration -v .` all passing
+- **Integration Testing**: A cross-feature smoke test confirming the loaded content still gets a cache point (#83) and that an explicit `--system` correctly suppresses discovery (FR2)

--- a/aidlc-docs/inception/requirements/agents-md-convention-questions.md
+++ b/aidlc-docs/inception/requirements/agents-md-convention-questions.md
@@ -13,7 +13,7 @@ C) `prompt` only
 
 D) Other (please describe after [Answer]: tag below)
 
-[Answer]:
+[Answer]: B
 
 ## Question 2
 Should this be automatic/always-on (matching how Claude Code/Cursor/etc. silently load their convention files), or opt-in like tool use (`--tools`) was?
@@ -26,7 +26,7 @@ C) Opt-in via config only (`chat-cli config set context-files ...`), no CLI flag
 
 D) Other (please describe after [Answer]: tag below)
 
-[Answer]:
+[Answer]: A
 
 ## Question 3
 How should the project-context file's content combine with an explicit `--system` flag or configured `system-prompt` (from #81) when both are present?
@@ -39,7 +39,7 @@ C) Project-context file is the base, explicit `--system` flag can only append to
 
 D) Other (please describe after [Answer]: tag below)
 
-[Answer]:
+[Answer]: B (user clarified in chat as "override wins" - explicit --system flag / configured system-prompt takes precedence entirely over the project-context file)
 
 ## Question 4
 What scope should Cursor's convention get in this first pass, given `.cursor/rules/*.mdc` is a directory of multiple frontmatter-scoped files (structurally different from a single flat markdown file), while `.cursorrules` is a legacy single-file format?
@@ -52,7 +52,7 @@ C) Drop Cursor support entirely from this pass; only cover `AGENTS.md`, `CLAUDE.
 
 D) Other (please describe after [Answer]: tag below)
 
-[Answer]:
+[Answer]: C
 
 ## Question 5
 How far should the walk-up-to-repo-root search go if the file isn't found in the current directory?
@@ -65,4 +65,4 @@ C) Walk up unconditionally until filesystem root if no `.git` is found
 
 D) Other (please describe after [Answer]: tag below)
 
-[Answer]:
+[Answer]: A (AI best judgment, per user's "don't know, use best judgment" - the .git-boundary walk-up is the safest default: avoids scanning unrelated ancestor directories while still finding the file from any subdirectory of the repo)

--- a/aidlc-docs/inception/requirements/agents-md-convention-questions.md
+++ b/aidlc-docs/inception/requirements/agents-md-convention-questions.md
@@ -1,0 +1,68 @@
+# Requirements Clarification Questions - Universal Project-Context File Convention (#88)
+
+Most of the design was already settled in conversation (priority list order, no-merge/first-match-wins policy, configurable file list via a config key, size guard, prompt-cache synergy with #83). These questions cover the remaining open parameters before requirements.md is written.
+
+## Question 1
+Which command(s) should auto-load the project-context file into the system prompt?
+
+A) Both `chat` and `prompt` (consistent with how `--system` already works in both, from #81)
+
+B) `chat` only (project-context feels most relevant to a longer interactive session)
+
+C) `prompt` only
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 2
+Should this be automatic/always-on (matching how Claude Code/Cursor/etc. silently load their convention files), or opt-in like tool use (`--tools`) was?
+
+A) Automatic by default - matches the convention other agentic tools already follow, with a way to disable it (flag/config) for users who don't want it
+
+B) Opt-in via a flag (e.g. `--agents-file`), off unless explicitly requested
+
+C) Opt-in via config only (`chat-cli config set context-files ...`), no CLI flag needed for v1
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 3
+How should the project-context file's content combine with an explicit `--system` flag or configured `system-prompt` (from #81) when both are present?
+
+A) Include both - project-context file content plus the explicit system prompt, as separate blocks (file first, then explicit prompt)
+
+B) Explicit `--system`/config `system-prompt` wins entirely - project-context file is ignored if either is set
+
+C) Project-context file is the base, explicit `--system` flag can only append to it (config `system-prompt` is ignored in favor of the file)
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 4
+What scope should Cursor's convention get in this first pass, given `.cursor/rules/*.mdc` is a directory of multiple frontmatter-scoped files (structurally different from a single flat markdown file), while `.cursorrules` is a legacy single-file format?
+
+A) Support only the legacy single-file `.cursorrules` for now; defer `.cursor/rules/*.mdc` directory support to a follow-up issue
+
+B) Support both now (adds meaningfully more parsing complexity - directory scan + frontmatter handling - to this unit)
+
+C) Drop Cursor support entirely from this pass; only cover `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 5
+How far should the walk-up-to-repo-root search go if the file isn't found in the current directory?
+
+A) Walk up until a `.git` directory is found (repo root); if no `.git` anywhere in the path, check cwd only - don't walk indefinitely toward filesystem root
+
+B) cwd only, no walk-up (simplest, matches original #88 scope)
+
+C) Walk up unconditionally until filesystem root if no `.git` is found
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:

--- a/aidlc-docs/inception/requirements/agents-md-convention-requirements.md
+++ b/aidlc-docs/inception/requirements/agents-md-convention-requirements.md
@@ -1,0 +1,68 @@
+# Requirements: Universal Project-Context File Convention (#88)
+
+## Intent Analysis Summary
+
+- **User Request**: Following completion of the Bedrock capability catch-up initiative (#81-#85), user asked to discuss Phase 2 (the "agentic direction" group of issues: #86-#88). After discussing all three, user chose to redefine #88 from a chat-cli-specific `CHATCLI.md` idea into a universal `AGENTS.md`-first convention that also respects other tools' existing convention files already present in a repo (`CLAUDE.md`, Cursor rules, Copilot instructions), so users don't have to duplicate project context that's already written for another agentic tool.
+- **Request Type**: New Feature (single cohesive capability)
+- **Scope Estimate**: Single Component — new file-discovery/loading logic feeding into the existing system-prompt pipeline (`cmd/systemprompt.go`, `cmd/chat.go`) from #81
+- **Complexity Estimate**: Simple — no new control flow like tool use introduced; this is discovery + read + compose, on top of already-existing system-prompt plumbing
+- **Related GitHub Issue**: [#88](https://github.com/chat-cli/chat-cli/issues/88)
+- **Depth**: Standard — one feature, but with several concrete precedence/scope decisions that need to be explicit since they affect UX and aren't obvious defaults
+
+## Clarifying Questions and Answers
+
+See `aidlc-docs/inception/requirements/agents-md-convention-questions.md` for the full record. Summary of decisions:
+
+1. **Scope**: `chat` only (not `prompt` — project-context is a longer-session concept, matching the interactive-agent use case).
+2. **Activation**: Automatic by default — no flag needed, matching how Claude Code/Cursor/etc. silently load their convention files. A way to disable it is still required (see FR6) since automatic, silent system-prompt injection needs an escape hatch.
+3. **Precedence vs. explicit system prompt**: An explicit `--system` flag or configured `system-prompt` (from #81) wins entirely — the project-context file is not loaded at all if either is set. This is a simpler mental model than merging two system-prompt sources and avoids surprising interactions with #81's existing precedence chain.
+4. **Cursor scope**: Dropped from this pass entirely. Only `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are in scope. Cursor's real convention (`.cursor/rules/*.mdc`, a directory of frontmatter-scoped files) is structurally different enough from a flat markdown file that it deserves its own follow-up issue rather than a bolt-on here.
+5. **Directory walk-up**: AI's best judgment (user deferred) — walk up from cwd toward the filesystem root, stopping at (and including) the first directory containing a `.git` entry; if no `.git` is found anywhere in the ancestry, only check the original cwd. This mirrors how Claude Code/Cursor resolve these files (repo-root-relative) while avoiding scanning unrelated ancestor directories when not inside a repo.
+
+## Assumptions Made (flag in "Request Changes" if any are wrong)
+
+1. **Filename precedence list is fixed at**: `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, in that order — first match wins, no concatenation of multiple files. `README.md` is explicitly excluded (too noisy/human-oriented for this to be a good automatic default).
+2. **The list is configurable** via a new `context-files` config key (comma-separated, same config precedence pattern as `model-id`/`system-prompt`), so a user can reorder, trim, or extend it without a code change. The three built-in filenames above are the default when the config key is unset.
+3. **Disabling it**: since this is automatic-by-default (decision 2 above), a `--no-context-file` flag (or an explicit empty `context-files` config value) is the escape hatch. `--system` already implicitly disables it per decision 3.
+4. **Size guard**: content past 32KB is truncated (with a one-line warning to stderr) before being folded into the system prompt, to avoid a large file silently dominating the context window or the request. 32KB is a reasonable, generous ceiling for hand-written instruction files — most real-world `AGENTS.md`/`CLAUDE.md` files are a few KB.
+5. **Cache synergy with #83**: the loaded file content is treated exactly like the existing system prompt for caching purposes — it flows through `buildSystemContentBlocks`/`withSystemCachePoint` so it gets the same automatic cache-point treatment already in place, no special-casing needed.
+6. **Case sensitivity**: filename matching is exact-case (`AGENTS.md`, not `agents.md`), matching how the equivalent tools' own conventions behave and how most filesystems Go targets are actually case-sensitive (Linux/most CI); case-insensitive matching is not attempted.
+
+## Functional Requirements
+
+### FR1 — Automatic Discovery
+- FR1.1: On `chat` startup, if neither `--system` nor a configured `system-prompt` is set, the CLI searches for a project-context file using the configured (or default) filename precedence list.
+- FR1.2: Search starts in the current working directory. If no match is found there, the CLI walks up parent directories, stopping at (and including) the first directory containing a `.git` entry. If no `.git` is found in the ancestry, only the original cwd is checked.
+- FR1.3: The first matching filename (in precedence order) at the first directory level that has any match is used. No merging of multiple files, even across different directory levels.
+
+### FR2 — Precedence Over Explicit System Prompt
+- FR2.1: If `--system` is passed, or a `system-prompt` config value is set, the project-context file is not searched for or loaded at all — the explicit value is used exactly as #81 already behaves today.
+
+### FR3 — Content Loading and Composition
+- FR3.1: The matched file's content becomes the system prompt for the session, via the existing `buildSystemContentBlocks` path from #81.
+- FR3.2: Content longer than 32KB is truncated to 32KB with a one-line warning printed to stderr (not stdout, so it doesn't pollute piped output).
+- FR3.3: The loaded content flows through the existing prompt-caching logic (#83) unchanged — a cache point is attached the same way it is for an explicit system prompt.
+
+### FR4 — Configurable File List
+- FR4.1: A new `context-files` config key (`chat-cli config set/unset/list`) holds a comma-separated, ordered list of filenames overriding the default `AGENTS.md,CLAUDE.md,.github/copilot-instructions.md` precedence list.
+
+### FR5 — Disabling
+- FR5.1: A `--no-context-file` flag on `chat` disables discovery for that invocation regardless of config.
+- FR5.2: Setting `context-files` to an empty string via config disables discovery by default (until overridden per-invocation... there is no positive override needed since `--system` already takes precedence per FR2).
+
+### FR6 — Visibility
+- FR6.1: When a project-context file is loaded, `chat` prints a one-line notice identifying which file was used (e.g. `Using project context: AGENTS.md`), so the user isn't left guessing why the model's behavior changed. This uses the same dim/gray styling convention already used for other session metadata in `chat.go`.
+
+## Non-Functional Requirements
+
+- **NFR1 — Backward Compatibility**: Existing `chat` behavior (no `--system`, no config, no project-context file present) is completely unchanged. Existing integration tests must continue to pass unmodified.
+- **NFR2 — TDD & Coverage**: Tests written before implementation, per `CLAUDE.md`. `cmd` package coverage must not regress.
+- **NFR3 — Security**: File discovery is read-only and confined to the cwd-to-git-root walk-up path (FR1.2) — no arbitrary filesystem access, no symlink-following concerns beyond what a normal file read already has. This reuses the spirit of `utils.ValidateLocalPath` from #82/#84, adapted for a directory search rather than a single user-supplied path.
+- **NFR4 — Reliability**: A missing, unreadable, or empty candidate file is treated as "no match" and search continues to the next filename/directory level — never a fatal error.
+- **NFR5 — Performance**: The walk-up search is bounded by the filesystem's actual directory depth (typically single-digit levels in practice) and runs once at `chat` startup, not per-turn.
+
+## Out of Scope (this pass)
+- `prompt` command support (decision 1) — could be a fast follow if wanted later.
+- Cursor's native `.cursor/rules/*.mdc` convention (decision 4) — tracked as a candidate follow-up issue if requested.
+- `README.md` as an automatic fallback — remains available only via explicit `context-files` config, never a built-in default.
+- Merging multiple matched files together — first-match-wins only.

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -108,10 +108,38 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 			log.Fatal(err)
 		}
 
+		noContextFile, err := flagCmd.PersistentFlags().GetBool("no-context-file")
+		if err != nil {
+			log.Fatalf("unable to get flag: %v", err)
+		}
+
 		// Get configuration values with precedence order (flag -> config -> default)
 		modelId := fm.GetConfigValue("model-id", modelIdFlag, DefaultModelID).(string)
 		customArn := fm.GetConfigValue("custom-arn", customArnFlag, "").(string)
 		systemPrompt := fm.GetConfigValue("system-prompt", systemFlag, "").(string)
+
+		// #88: when no explicit system prompt was supplied (flag or config),
+		// automatically discover a project-context file (AGENTS.md/CLAUDE.md/
+		// .github/copilot-instructions.md, or a configured override) and use
+		// it as the system prompt, unless disabled via --no-context-file or
+		// an empty context-files config value.
+		if systemPrompt == "" && !noContextFile {
+			contextFilesConfig := fm.GetConfigValue("context-files", "", "").(string)
+			candidates := resolveContextFilenames(contextFilesConfig)
+
+			if len(candidates) > 0 {
+				if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+					content, sourcePath, truncated, found := resolveAndLoadProjectContext(cwd, candidates)
+					if found {
+						if truncated {
+							fmt.Fprintf(os.Stderr, "warning: project context file %s exceeds 32KB and was truncated\n", sourcePath)
+						}
+						systemPrompt = content
+						fmt.Printf("\033[90mUsing project context: %s\033[0m\n", sourcePath)
+					}
+				}
+			}
+		}
 
 		// Ensure custom-arn takes precedence over model-id when both are set
 		// If custom-arn is set (from any source), use it; otherwise use model-id

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -125,17 +125,21 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 		// an empty context-files config value.
 		if systemPrompt == "" && !noContextFile {
 			contextFilesConfig := fm.GetConfigValue("context-files", "", "").(string)
-			candidates := resolveContextFilenames(contextFilesConfig)
+			candidates := resolveContextFilenames(contextFilesConfig, fm.IsConfigSet("context-files"))
 
 			if len(candidates) > 0 {
-				if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+				cwd, cwdErr := os.Getwd()
+				if cwdErr != nil {
+					fmt.Fprintf(os.Stderr, "warning: unable to determine current directory for project context discovery: %v\n", cwdErr)
+				} else {
 					content, sourcePath, truncated, found := resolveAndLoadProjectContext(cwd, candidates)
 					if found {
+						displayPath := formatProjectContextDisplayPath(cwd, sourcePath)
 						if truncated {
-							fmt.Fprintf(os.Stderr, "warning: project context file %s exceeds 32KB and was truncated\n", sourcePath)
+							fmt.Fprintf(os.Stderr, "warning: project context file %s exceeds 32KB and was truncated\n", displayPath)
 						}
 						systemPrompt = content
-						fmt.Printf("\033[90mUsing project context: %s\033[0m\n", sourcePath)
+						fmt.Printf("\033[90mUsing project context: %s\033[0m\n", displayPath)
 					}
 				}
 			}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -144,6 +144,14 @@ func TestConfigCommandSupportsSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestConfigCommandSupportsContextFiles(t *testing.T) {
+	// #88 (universal AGENTS.md convention): "context-files" must be a
+	// supported config key, same as "system-prompt".
+	if !supportedConfigKeys["context-files"] {
+		t.Error("Expected 'context-files' to be a supported config key")
+	}
+}
+
 func TestVersionCommand(t *testing.T) {
 	// Test that version command exists
 	if versionCmd.Use != "version" {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,13 +29,14 @@ var supportedConfigKeys = map[string]bool{
 	"custom-arn":    true,
 	"model-id":      true,
 	"system-prompt": true,
+	"context-files": true,
 }
 
 // configSetCmd represents the config set command
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a configuration value",
-	Long:  `Set a configuration value. Supported keys: custom-arn, model-id, system-prompt`,
+	Long:  `Set a configuration value. Supported keys: custom-arn, model-id, system-prompt, context-files`,
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize configuration
@@ -54,7 +55,7 @@ var configSetCmd = &cobra.Command{
 		// Validate supported keys
 		if !supportedConfigKeys[key] {
 			fmt.Printf("Error: unsupported configuration key '%s'\n", key)
-			fmt.Println("Supported keys: custom-arn, model-id, system-prompt")
+			fmt.Println("Supported keys: custom-arn, model-id, system-prompt, context-files")
 			os.Exit(1)
 		}
 
@@ -75,7 +76,7 @@ var configSetCmd = &cobra.Command{
 var configUnsetCmd = &cobra.Command{
 	Use:   "unset <key>",
 	Short: "Unset a configuration value",
-	Long:  `Unset (remove) a configuration value. Supported keys: custom-arn, model-id, system-prompt`,
+	Long:  `Unset (remove) a configuration value. Supported keys: custom-arn, model-id, system-prompt, context-files`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize configuration
@@ -93,7 +94,7 @@ var configUnsetCmd = &cobra.Command{
 		// Validate supported keys
 		if !supportedConfigKeys[key] {
 			fmt.Printf("Error: unsupported configuration key '%s'\n", key)
-			fmt.Println("Supported keys: custom-arn, model-id, system-prompt")
+			fmt.Println("Supported keys: custom-arn, model-id, system-prompt, context-files")
 			os.Exit(1)
 		}
 
@@ -156,7 +157,7 @@ var configListCmd = &cobra.Command{
 		fmt.Println("Current configuration:")
 
 		// Define the keys we care about
-		configKeys := []string{"custom-arn", "model-id", "system-prompt"}
+		configKeys := []string{"custom-arn", "model-id", "system-prompt", "context-files"}
 
 		hasConfig := false
 		for _, key := range configKeys {

--- a/cmd/projectcontext.go
+++ b/cmd/projectcontext.go
@@ -1,0 +1,160 @@
+/*
+Copyright © 2024 Micah Walter
+*/
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxContextFileSize is the size (in bytes) at which project-context file
+// content is truncated before being used as the system prompt (BR9).
+const maxContextFileSize = 32 * 1024
+
+// maxWalkUpLevels bounds the upward .git-boundary search (NFR design note)
+// as a defensive cap against a pathologically deep cwd with no repo above it.
+const maxWalkUpLevels = 64
+
+// defaultContextFilenames is the default precedence list (BR5) used when the
+// context-files config key is unset.
+var defaultContextFilenames = []string{"AGENTS.md", "CLAUDE.md", ".github/copilot-instructions.md"}
+
+// resolveContextFilenames implements BR11-BR13: parses a comma-separated
+// context-files config value into an ordered candidate list, trimming
+// whitespace and dropping empty entries. An unset (empty) configValue yields
+// the default list; a value that trims down to zero entries yields an empty
+// list (the disable case, BR12).
+func resolveContextFilenames(configValue string) []string {
+	if configValue == "" {
+		return defaultContextFilenames
+	}
+
+	parts := strings.Split(configValue, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+// findProjectContextFile implements the Phase A / Phase B algorithm from
+// business-logic-model.md: it walks up from cwd (stat-only, capped at
+// maxWalkUpLevels) looking for a .git boundary, then checks candidates (in
+// precedence order, BR3) at cwd first and, if no match there, at the
+// boundary directory (BR4). It returns the matched path and which candidate
+// string matched (so callers can exclude it and keep searching, per BR8).
+func findProjectContextFile(cwd string, candidates []string) (path string, matchedCandidate string, ok bool) {
+	if len(candidates) == 0 {
+		return "", "", false
+	}
+
+	if path, matched, found := matchCandidateInDir(cwd, candidates); found {
+		return path, matched, true
+	}
+
+	boundary := findGitBoundary(cwd)
+	if boundary == "" || boundary == cwd {
+		return "", "", false
+	}
+
+	if path, matched, found := matchCandidateInDir(boundary, candidates); found {
+		return path, matched, true
+	}
+
+	return "", "", false
+}
+
+// matchCandidateInDir checks candidates (in order) against dir, returning
+// the first one that resolves to a regular, readable file (BR2/BR3).
+func matchCandidateInDir(dir string, candidates []string) (path string, matchedCandidate string, ok bool) {
+	for _, candidate := range candidates {
+		candidatePath := filepath.Join(dir, candidate)
+		info, err := os.Stat(candidatePath)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		return candidatePath, candidate, true
+	}
+	return "", "", false
+}
+
+// findGitBoundary walks upward from dir looking for the first ancestor
+// (inclusive) containing a .git entry, capped at maxWalkUpLevels. Returns ""
+// if none is found.
+func findGitBoundary(dir string) string {
+	current := dir
+	for i := 0; i < maxWalkUpLevels; i++ {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			// reached filesystem root
+			return ""
+		}
+		current = parent
+	}
+	return ""
+}
+
+// loadProjectContext implements BR7-BR10: reads path, trims surrounding
+// whitespace, and truncates to maxContextFileSize if needed. A read error
+// (permission denied, race-condition deletion, path is a directory, etc.)
+// is returned as err for the caller to treat as "no match" (BR10) - this
+// function does not decide search-continuation policy.
+func loadProjectContext(path string) (content string, truncated bool, originalSize int, err error) {
+	data, err := os.ReadFile(path) // nolint:gosec // path is resolved from a fixed, known candidate list, not user-supplied
+	if err != nil {
+		return "", false, 0, err
+	}
+
+	originalSize = len(data)
+	trimmed := strings.TrimSpace(string(data))
+
+	if len(trimmed) > maxContextFileSize {
+		return trimmed[:maxContextFileSize], true, originalSize, nil
+	}
+
+	return trimmed, false, originalSize, nil
+}
+
+// resolveAndLoadProjectContext is the composition root tying discovery and
+// loading together, including BR8's rule that an empty-after-trim match (or
+// an unreadable one, BR10) is treated as no match and search continues with
+// the next candidate.
+func resolveAndLoadProjectContext(cwd string, candidates []string) (content string, sourcePath string, truncated bool, found bool) {
+	remaining := append([]string(nil), candidates...)
+
+	for len(remaining) > 0 {
+		path, matched, ok := findProjectContextFile(cwd, remaining)
+		if !ok {
+			return "", "", false, false
+		}
+
+		loaded, trunc, _, err := loadProjectContext(path)
+		if err == nil && loaded != "" {
+			return loaded, path, trunc, true
+		}
+
+		remaining = removeString(remaining, matched)
+	}
+
+	return "", "", false, false
+}
+
+func removeString(list []string, target string) []string {
+	result := make([]string, 0, len(list))
+	for _, s := range list {
+		if s != target {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/cmd/projectcontext.go
+++ b/cmd/projectcontext.go
@@ -23,12 +23,15 @@ var defaultContextFilenames = []string{"AGENTS.md", "CLAUDE.md", ".github/copilo
 
 // resolveContextFilenames implements BR11-BR13: parses a comma-separated
 // context-files config value into an ordered candidate list, trimming
-// whitespace and dropping empty entries. An unset (empty) configValue yields
-// the default list; a value that trims down to zero entries yields an empty
-// list (the disable case, BR12).
-func resolveContextFilenames(configValue string) []string {
-	if configValue == "" {
+// whitespace and dropping empty entries. When configSet is false (key unset),
+// the default list is used. When configSet is true and configValue is empty
+// or trims down to zero entries, an empty list is returned (BR12 disable).
+func resolveContextFilenames(configValue string, configSet bool) []string {
+	if !configSet {
 		return defaultContextFilenames
+	}
+	if configValue == "" {
+		return []string{}
 	}
 
 	parts := strings.Split(configValue, ",")
@@ -75,13 +78,37 @@ func findProjectContextFile(cwd string, candidates []string) (path string, match
 func matchCandidateInDir(dir string, candidates []string) (path string, matchedCandidate string, ok bool) {
 	for _, candidate := range candidates {
 		candidatePath := filepath.Join(dir, candidate)
-		info, err := os.Stat(candidatePath)
-		if err != nil || !info.Mode().IsRegular() {
+		if !isContextFileMatch(candidatePath) {
 			continue
 		}
 		return candidatePath, candidate, true
 	}
 	return "", "", false
+}
+
+// isContextFileMatch reports whether path is a regular file or a symlink to
+// one (BR2). Directories and other non-file entries are rejected.
+func isContextFileMatch(path string) bool {
+	f, err := os.Open(path) // nolint:gosec // path is from a fixed candidate list, not user-supplied
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+// formatProjectContextDisplayPath returns a cwd-relative path for the notice
+// (BR16), falling back to the basename when relative resolution fails.
+func formatProjectContextDisplayPath(cwd, sourcePath string) string {
+	if rel, err := filepath.Rel(cwd, sourcePath); err == nil && rel != "" && rel != "." {
+		return rel
+	}
+	return filepath.Base(sourcePath)
 }
 
 // findGitBoundary walks upward from dir looking for the first ancestor

--- a/cmd/projectcontext_test.go
+++ b/cmd/projectcontext_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright © 2024 Micah Walter
+*/
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveContextFilenames(t *testing.T) {
+	tests := []struct {
+		name        string
+		configValue string
+		want        []string
+	}{
+		{
+			name:        "unset config value yields the default precedence list",
+			configValue: "",
+			want:        []string{"AGENTS.md", "CLAUDE.md", ".github/copilot-instructions.md"},
+		},
+		{
+			name:        "custom comma-separated list is parsed and trimmed",
+			configValue: "CLAUDE.md, AGENTS.md ,README.md",
+			want:        []string{"CLAUDE.md", "AGENTS.md", "README.md"},
+		},
+		{
+			name:        "empty entries from stray commas are dropped",
+			configValue: "AGENTS.md,,CLAUDE.md,",
+			want:        []string{"AGENTS.md", "CLAUDE.md"},
+		},
+		{
+			name:        "a value that trims down to nothing yields an empty list (disable case)",
+			configValue: "  ,  ,",
+			want:        []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveContextFilenames(tt.configValue)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("expected %v, got %v", tt.want, got)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestFindProjectContextFile(t *testing.T) {
+	t.Run("matches a candidate in cwd", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "AGENTS.md"), "hello")
+
+		path, _, ok := findProjectContextFile(dir, []string{"AGENTS.md", "CLAUDE.md"})
+		if !ok {
+			t.Fatal("expected a match, got none")
+		}
+		if path != filepath.Join(dir, "AGENTS.md") {
+			t.Errorf("expected match at %s, got %s", filepath.Join(dir, "AGENTS.md"), path)
+		}
+	})
+
+	t.Run("no match anywhere yields ok=false", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, _, ok := findProjectContextFile(dir, []string{"AGENTS.md"})
+		if ok {
+			t.Fatal("expected no match")
+		}
+	})
+
+	t.Run("a directory with a matching name is not treated as a match", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(dir, "AGENTS.md"), 0750); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+
+		_, _, ok := findProjectContextFile(dir, []string{"AGENTS.md"})
+		if ok {
+			t.Fatal("expected no match - a directory should not count as a match")
+		}
+	})
+
+	t.Run("matches at the git-boundary parent when cwd has no match", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0750); err != nil {
+			t.Fatalf("failed to create .git dir: %v", err)
+		}
+		writeFile(t, filepath.Join(root, "CLAUDE.md"), "hello")
+
+		sub := filepath.Join(root, "a", "b", "c")
+		if err := os.MkdirAll(sub, 0750); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+
+		path, _, ok := findProjectContextFile(sub, []string{"AGENTS.md", "CLAUDE.md"})
+		if !ok {
+			t.Fatal("expected a match at the git-boundary parent")
+		}
+		if path != filepath.Join(root, "CLAUDE.md") {
+			t.Errorf("expected match at %s, got %s", filepath.Join(root, "CLAUDE.md"), path)
+		}
+	})
+
+	t.Run("cwd match takes precedence over a boundary match", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0750); err != nil {
+			t.Fatalf("failed to create .git dir: %v", err)
+		}
+		writeFile(t, filepath.Join(root, "AGENTS.md"), "root version")
+
+		sub := filepath.Join(root, "a")
+		if err := os.MkdirAll(sub, 0750); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+		writeFile(t, filepath.Join(sub, "AGENTS.md"), "sub version")
+
+		path, _, ok := findProjectContextFile(sub, []string{"AGENTS.md"})
+		if !ok {
+			t.Fatal("expected a match")
+		}
+		if path != filepath.Join(sub, "AGENTS.md") {
+			t.Errorf("expected cwd match at %s, got %s", filepath.Join(sub, "AGENTS.md"), path)
+		}
+	})
+
+	t.Run("no .git anywhere means only cwd is checked", func(t *testing.T) {
+		// t.TempDir() is nested well outside any git repo boundary within itself.
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "a", "b")
+		if err := os.MkdirAll(sub, 0750); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+		writeFile(t, filepath.Join(dir, "AGENTS.md"), "hello")
+
+		_, _, ok := findProjectContextFile(sub, []string{"AGENTS.md"})
+		if ok {
+			t.Fatal("expected no match since no .git boundary exists between sub and dir")
+		}
+	})
+}
+
+func TestLoadProjectContext(t *testing.T) {
+	t.Run("reads and trims content", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "AGENTS.md")
+		writeFile(t, path, "  hello world  \n")
+
+		content, truncated, originalSize, err := loadProjectContext(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "hello world" {
+			t.Errorf("expected trimmed content %q, got %q", "hello world", content)
+		}
+		if truncated {
+			t.Error("did not expect truncation")
+		}
+		if originalSize != len("  hello world  \n") {
+			t.Errorf("expected originalSize %d, got %d", len("  hello world  \n"), originalSize)
+		}
+	})
+
+	t.Run("truncates content over 32KB", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "AGENTS.md")
+		big := strings.Repeat("a", 32*1024+100)
+		writeFile(t, path, big)
+
+		content, truncated, originalSize, err := loadProjectContext(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !truncated {
+			t.Error("expected truncation")
+		}
+		if len(content) != 32*1024 {
+			t.Errorf("expected truncated content of exactly 32KB, got %d bytes", len(content))
+		}
+		if originalSize != len(big) {
+			t.Errorf("expected originalSize %d, got %d", len(big), originalSize)
+		}
+	})
+
+	t.Run("content under 32KB is not truncated", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "AGENTS.md")
+		writeFile(t, path, strings.Repeat("a", 100))
+
+		_, truncated, _, err := loadProjectContext(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if truncated {
+			t.Error("did not expect truncation")
+		}
+	})
+
+	t.Run("an unreadable path returns an error", func(t *testing.T) {
+		dir := t.TempDir()
+		// A directory is not a readable "file" in the sense this function needs.
+		_, _, _, err := loadProjectContext(dir)
+		if err == nil {
+			t.Fatal("expected an error reading a directory as a file")
+		}
+	})
+}
+
+func TestResolveAndLoadProjectContext(t *testing.T) {
+	t.Run("finds and loads a match", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "AGENTS.md"), "you are helpful")
+
+		content, sourcePath, truncated, found := resolveAndLoadProjectContext(dir, []string{"AGENTS.md", "CLAUDE.md"})
+		if !found {
+			t.Fatal("expected a match")
+		}
+		if content != "you are helpful" {
+			t.Errorf("expected content %q, got %q", "you are helpful", content)
+		}
+		if sourcePath != filepath.Join(dir, "AGENTS.md") {
+			t.Errorf("expected sourcePath %s, got %s", filepath.Join(dir, "AGENTS.md"), sourcePath)
+		}
+		if truncated {
+			t.Error("did not expect truncation")
+		}
+	})
+
+	t.Run("an empty-after-trim file is skipped in favor of the next candidate", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "AGENTS.md"), "   \n  ")
+		writeFile(t, filepath.Join(dir, "CLAUDE.md"), "real content")
+
+		content, sourcePath, _, found := resolveAndLoadProjectContext(dir, []string{"AGENTS.md", "CLAUDE.md"})
+		if !found {
+			t.Fatal("expected a match (should have skipped the vacuous AGENTS.md)")
+		}
+		if content != "real content" {
+			t.Errorf("expected content %q, got %q", "real content", content)
+		}
+		if sourcePath != filepath.Join(dir, "CLAUDE.md") {
+			t.Errorf("expected sourcePath %s, got %s", filepath.Join(dir, "CLAUDE.md"), sourcePath)
+		}
+	})
+
+	t.Run("no candidates match anywhere yields found=false", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, _, _, found := resolveAndLoadProjectContext(dir, []string{"AGENTS.md", "CLAUDE.md"})
+		if found {
+			t.Fatal("expected no match")
+		}
+	})
+
+	t.Run("empty candidate list yields found=false without touching the filesystem", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "AGENTS.md"), "content")
+
+		_, _, _, found := resolveAndLoadProjectContext(dir, []string{})
+		if found {
+			t.Fatal("expected no match when the candidate list is empty")
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}

--- a/cmd/projectcontext_test.go
+++ b/cmd/projectcontext_test.go
@@ -14,33 +14,44 @@ func TestResolveContextFilenames(t *testing.T) {
 	tests := []struct {
 		name        string
 		configValue string
+		configSet   bool
 		want        []string
 	}{
 		{
-			name:        "unset config value yields the default precedence list",
+			name:        "unset config key yields the default precedence list",
 			configValue: "",
+			configSet:   false,
 			want:        []string{"AGENTS.md", "CLAUDE.md", ".github/copilot-instructions.md"},
+		},
+		{
+			name:        "explicitly set empty config value disables discovery",
+			configValue: "",
+			configSet:   true,
+			want:        []string{},
 		},
 		{
 			name:        "custom comma-separated list is parsed and trimmed",
 			configValue: "CLAUDE.md, AGENTS.md ,README.md",
+			configSet:   true,
 			want:        []string{"CLAUDE.md", "AGENTS.md", "README.md"},
 		},
 		{
 			name:        "empty entries from stray commas are dropped",
 			configValue: "AGENTS.md,,CLAUDE.md,",
+			configSet:   true,
 			want:        []string{"AGENTS.md", "CLAUDE.md"},
 		},
 		{
 			name:        "a value that trims down to nothing yields an empty list (disable case)",
 			configValue: "  ,  ,",
+			configSet:   true,
 			want:        []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveContextFilenames(tt.configValue)
+			got := resolveContextFilenames(tt.configValue, tt.configSet)
 
 			if len(got) != len(tt.want) {
 				t.Fatalf("expected %v, got %v", tt.want, got)
@@ -87,6 +98,24 @@ func TestFindProjectContextFile(t *testing.T) {
 		_, _, ok := findProjectContextFile(dir, []string{"AGENTS.md"})
 		if ok {
 			t.Fatal("expected no match - a directory should not count as a match")
+		}
+	})
+
+	t.Run("a symlink to a regular file is treated as a match", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "instructions.md")
+		writeFile(t, target, "hello")
+		link := filepath.Join(dir, "AGENTS.md")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skip("symlinks not supported in this environment")
+		}
+
+		path, _, ok := findProjectContextFile(dir, []string{"AGENTS.md"})
+		if !ok {
+			t.Fatal("expected a match via symlink")
+		}
+		if path != link {
+			t.Errorf("expected match at %s, got %s", link, path)
 		}
 	})
 
@@ -268,6 +297,30 @@ func TestResolveAndLoadProjectContext(t *testing.T) {
 		_, _, _, found := resolveAndLoadProjectContext(dir, []string{})
 		if found {
 			t.Fatal("expected no match when the candidate list is empty")
+		}
+	})
+}
+
+func TestFormatProjectContextDisplayPath(t *testing.T) {
+	t.Run("returns basename when file is in cwd", func(t *testing.T) {
+		cwd := "/repo"
+		source := "/repo/AGENTS.md"
+		got := formatProjectContextDisplayPath(cwd, source)
+		if got != "AGENTS.md" {
+			t.Errorf("expected AGENTS.md, got %q", got)
+		}
+	})
+
+	t.Run("returns relative path when file is at repo root from nested cwd", func(t *testing.T) {
+		cwd := "/repo/a/b"
+		source := "/repo/AGENTS.md"
+		want, err := filepath.Rel(cwd, source)
+		if err != nil {
+			t.Fatalf("unexpected rel error: %v", err)
+		}
+		got := formatProjectContextDisplayPath(cwd, source)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
 		}
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().String("custom-arn", "", "pass a custom arn from bedrock marketplace or cross-region inference")
 	rootCmd.PersistentFlags().String("chat-id", "", "pass a valid chat-id to load a previous conversation")
 	rootCmd.PersistentFlags().String("system", "", "set a system prompt")
+	rootCmd.PersistentFlags().Bool("no-context-file", false, "disable automatic project-context file discovery (AGENTS.md/CLAUDE.md/etc., chat only)")
 	rootCmd.PersistentFlags().Bool("tools", false, "enable tool use (chat only)")
 	rootCmd.PersistentFlags().Bool("thinking", false, "enable extended thinking / reasoning mode")
 	rootCmd.PersistentFlags().Int32("thinking-budget", 1024, "token budget for extended thinking on legacy models (requires --thinking)")

--- a/config/config.go
+++ b/config/config.go
@@ -155,3 +155,8 @@ func (fm *FileManager) GetConfigValue(key string, flagValue, defaultValue interf
 	// Return default value
 	return defaultValue
 }
+
+// IsConfigSet reports whether key is explicitly set in the configuration file.
+func (fm *FileManager) IsConfigSet(key string) bool {
+	return viper.IsSet(key)
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,6 +127,31 @@ chat-cli --system "You are a terse, no-nonsense assistant."
 
 Like `prompt`, this falls back to the persisted `system-prompt` config value, then to no system prompt at all.
 
+### Project Context
+
+If you don't set `--system` or a `system-prompt` config value, `chat` automatically looks for a project-context file and uses it as the system prompt — no flag needed. It checks, in order, `AGENTS.md`, `CLAUDE.md`, then `.github/copilot-instructions.md`, first in your current directory, then (if not found there) at your repository root. The first match wins; files aren't merged together.
+
+When a file is used, you'll see a one-line notice at the start of the session:
+
+```
+Using project context: AGENTS.md
+```
+
+To customize which filenames are checked (and in what order), set the `context-files` config value to a comma-separated list:
+
+```shell
+chat-cli config set context-files "AGENTS.md,CLAUDE.md"
+```
+
+To disable discovery entirely for a session, pass `--no-context-file`, or set `context-files` to an empty string to disable it by default:
+
+```shell
+chat-cli --no-context-file
+chat-cli config set context-files ""
+```
+
+An explicit `--system` flag or configured `system-prompt` always takes full precedence — the project-context file is only ever considered when neither is set. Content over 32KB is truncated with a warning. This is currently `chat`-only; `prompt` isn't affected.
+
 ### Tool Use
 
 Pass `--tools` to let the model call tools mid-conversation:

--- a/integration_test.go
+++ b/integration_test.go
@@ -149,6 +149,7 @@ func TestCLIFlagsExist(t *testing.T) {
 		"--region",
 		"--model-id",
 		"--custom-arn",
+		"--no-context-file",
 	}
 
 	for _, flag := range expectedFlags {


### PR DESCRIPTION
## Summary

`chat` now automatically discovers and loads a project-context file as the system prompt, closing #88 — the first item from the "agentic direction" idea group (#86-#88) brainstormed after the Bedrock capability catch-up initiative (#81-#85, #97).

- Checks, in order, **`AGENTS.md`**, **`CLAUDE.md`**, then **`.github/copilot-instructions.md`** — first match wins, no merging.
- Searches the current directory first, then walks up to the nearest `.git` boundary if not found there — never further, and never reads file *content* outside those two directories (only ever stats for `.git`'s existence while walking).
- An explicit `--system` flag or configured `system-prompt` (from #81) always takes full precedence — discovery is only attempted when neither is set.
- The candidate filename list is customizable (or discovery disable-able) via a new `context-files` config key; `--no-context-file` disables it for a single session.
- Content over 32KB is truncated with a warning; a one-line startup notice (`Using project context: AGENTS.md`) identifies which file was used, so the behavior change is never silent.
- `chat`-only for this pass — `prompt` is untouched. Cursor's native `.cursor/rules/*.mdc` convention was scoped out (structurally different, directory-of-files vs. a flat file) and left for a possible follow-up issue.

### Notable implementation details
- Reuses Initiative 1's system-prompt (#81) and prompt-caching (#83) pipelines completely as-is — the loaded file content is indistinguishable from an explicit `--system` value once resolved, so it automatically gets a cache point too.
- The discovery/loading logic (`cmd/projectcontext.go`) is pure(ish) filesystem logic with no Bedrock SDK involvement, so it's tested directly with `t.TempDir()` fixtures — no mocking needed, unlike most of the tool-use/streaming work in #97.
- Verified against the actual compiled binary (not just unit tests): a manual smoke test confirmed discovery correctly walks up to a git boundary from a nested subdirectory, and that both `--system` and `--no-context-file` suppress it.

### Process
Built using AI-DLC (requirements → workflow planning → functional design/NFR → code generation → build and test). Given the narrow, single-component scope, User Stories/Application Design/Units Generation were judged disproportionate and skipped — see `aidlc-docs/inception/plans/agents-md-convention-execution-plan.md` for the full rationale. Full audit trail and design artifacts are under `aidlc-docs/`.

## Test plan

- [x] `make test` — all packages pass, no regressions
- [x] `make lint` — clean
- [x] `go test -tags=integration -v .` — all 7 integration tests pass (including an updated `TestCLIFlagsExist` for `--no-context-file`)
- [x] Coverage: 66.3% → 67.8% total (`cmd` 23.6% → 31.8%)
- [x] Manual smoke test against the compiled binary: discovery from a nested subdirectory, `--system` suppression, `--no-context-file` suppression — all confirmed working
- [x] No new real-credential-verification surface — this feature never talks to Bedrock directly, it only feeds into the existing (already-built) system-prompt request path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hxx6CHPFfwPpgF8uX7a9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hxx6CHPFfwPpgF8uX7a9Q)_