### PR TITLE
Add built-in agent tools: write_file, run_shell, git_diff with a confirmation gate

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -247,4 +247,8 @@ a verified ancestor of the merge commit before reset).
 
 ## Stage Progress
 - [x] Workspace Detection - Brownfield confirmed, reusing existing `aidlc-docs/aidlc-state.md` context (no re-run of Reverse Engineering - same rationale as Initiative 2, narrow addition to an already-understood `tools/` subsystem from Initiative 1 Unit 2)
-- [ ] Requirements Analysis - IN PROGRESS, clarifying questions issued
+- [x] Requirements Analysis - Completed 2026-07-08, awaiting user approval
+  - Two rounds of clarifying questions (initial 7 + a follow-up round of 4 after the user's freeform answer revealed a bigger scope than originally asked - automatic tool-use enablement replacing the `--tools` opt-in flag from Initiative 1, plus a new pattern-based sticky-approval permission engine)
+  - Artifacts: aidlc-docs/inception/requirements/builtin-tools-{questions,clarification-questions,requirements}.md
+  - FR1-FR7 + NFR1-NFR5 documented. Notably revises Initiative 1's NFR1 (backward compatibility) by design - tool use becomes always-on with automatic graceful degradation, per explicit user direction
+  - **Recommending User Stories EXECUTE (not skip)** this time - real UX/acceptance-criteria value given the new confirmation-gate/approval-tier interaction flows, unlike Initiative 2's simple flag/config plumbing

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -303,5 +303,12 @@ a verified ancestor of the merge commit before reset).
   - Artifacts: aidlc-docs/construction/unit-8-automatic-enablement/functional-design/business-logic-model.md, aidlc-docs/construction/unit-8-automatic-enablement/nfr-requirements/nfr-requirements-and-design.md
   - Key finding: "disabled for the rest of the session" (FR1.2) falls out for free from the existing mutable converseStreamInput struct - no new session-state tracking needed. The FR1.3 user notice reuses the existing log.Printf convention already used by the cache/sampling-params fallbacks.
   - **CAVEAT (same category as Unit 5's reasoning_config)**: isToolUseUnsupportedError's exact string-matching heuristic is UNVERIFIED against real Bedrock error text - added to the real-credential verification list.
-- [ ] Code Generation - Pending
+- [x] Code Generation - Completed 2026-07-08, awaiting user review/approval
+  - Plan: aidlc-docs/construction/plans/unit-8-automatic-enablement-code-generation-plan.md (all 5 steps complete)
+  - Summary: aidlc-docs/construction/unit-8-automatic-enablement/code/summary.md
+  - --tools flag fully removed (verified via chat-cli --help). Registry always contains all 4 tools unconditionally, verified via a real-components scratch driver.
+  - cmd 33.1%->33.5%, total 71.2%->70.9% (negligible dip, new fallback branch untested per established unmockable-client precedent), no other regressions. 7/7 integration tests pass.
+
+## Unit 8 Status: COMPLETE, AWAITING APPROVAL - ALL 3 UNITS OF INITIATIVE 3 CODE-COMPLETE
+
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -276,7 +276,12 @@ a verified ancestor of the merge commit before reset).
   - Artifacts: aidlc-docs/construction/unit-6-confirmation-engine/nfr-requirements/nfr-requirements-and-design.md
   - Security (dominant): Dispatch is the single choke point, fail-closed on every ambiguous state, per-repo scoping is a security boundary not just UX, 0600 file perms. Reliability: corrupted store degrades to empty (re-prompt), never fatal. Usability: informative prompts, stated truncation policy for large write_file content.
 - [x] Infrastructure Design - SKIP (no infrastructure in this project)
-- [x] Code Generation - Plan complete 2026-07-08, awaiting approval to begin generation
-  - Plan: aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md (14 TDD-ordered steps)
-  - Key finding during planning: Registry.Dispatch has exactly one call site (cmd/toolloop.go's runChatTurnWithTools), which must have a gate threaded through all 4 of its own call sites to keep the tree compiling - Unit 6 constructs a real InteractivePermissionGate now (inert until Unit 7 adds destructive tools) rather than leaving intermediate commits broken
+- [x] Code Generation - Completed 2026-07-08, awaiting user review/approval
+  - Plan: aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md (all 14 steps complete)
+  - Summary: aidlc-docs/construction/unit-6-confirmation-engine/code/summary.md
+  - cmd 31.8%->33.3%, tools 90.0%->84.1%, utils 51.8%->53.7%, total 67.8%->69.7%, no regressions. 7/7 integration tests pass. No user-visible behavior change yet (by design) - gate fully wired but inert until Unit 7.
+  - One caught-and-fixed deviation during implementation: persisted-entry format initially used the wrong (internal NUL-joined) key before being corrected to the documented human-readable "toolName:patternKey" format.
+
+## Unit 6 Status: COMPLETE, AWAITING APPROVAL
+
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -285,6 +285,9 @@ a verified ancestor of the merge commit before reset).
 ## Unit 6 Status: COMPLETE AND APPROVED (commit 2e04ef0)
 
 ### Construction Phase - Unit 7 (New Built-in Tools, #86)
-- [ ] Functional Design + NFR - Pending
+- [x] Functional Design + NFR - Completed 2026-07-08, awaiting user approval (combined presentation - lower novelty than Unit 6, applies its established pattern to 3 mechanical tools rather than introducing new architecture)
+  - Artifacts: aidlc-docs/construction/unit-7-new-tools/functional-design/{business-logic-model,business-rules,domain-entities}.md, aidlc-docs/construction/unit-7-new-tools/nfr-requirements/nfr-requirements-and-design.md
+  - Key finding: utils.ValidateLocalPath requires the target file to already exist (existence check baked in) - wrong for write_file's create-new-file case. Resolved additively: new utils.ValidateLocalPathForWrite (confinement-only) sharing a private confineToWorkingDir helper with the unchanged, existing ValidateLocalPath - zero regression risk to Units 2/4's already-shipped call sites.
+  - run_shell: 30s timeout, 32KB truncated combined output, non-zero exit code reported in output text (not a Go error) so the model sees command failures as normal operation, not tool bugs.
 - [ ] Code Generation - Pending
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -309,6 +309,12 @@ a verified ancestor of the merge commit before reset).
   - --tools flag fully removed (verified via chat-cli --help). Registry always contains all 4 tools unconditionally, verified via a real-components scratch driver.
   - cmd 33.1%->33.5%, total 71.2%->70.9% (negligible dip, new fallback branch untested per established unmockable-client precedent), no other regressions. 7/7 integration tests pass.
 
-## Unit 8 Status: COMPLETE, AWAITING APPROVAL - ALL 3 UNITS OF INITIATIVE 3 CODE-COMPLETE
+## Unit 8 Status: COMPLETE AND APPROVED (commit 9ba9005)
 
-- [ ] Build and Test - Pending all 3 units
+- [x] Build and Test - Completed 2026-07-08, awaiting final approval
+  - Artifacts: aidlc-docs/construction/build-and-test/builtin-tools-summary.md
+  - Fresh full test suite: all green, no regressions (total 67.8%->70.9% across the initiative)
+  - 4 cross-unit composition scenarios executed: --system+--thinking+always-on-tools combined, #88's --no-context-file+#86's always-on-tools combined, confirmation gate full end-to-end via real components (once/deny/session-reuse/gate-never-consulted-for-read-only), --tools fully removed (verified via --help)
+  - Consolidated real-credential verification list: isToolUseUnsupportedError heuristic (same risk category as Unit 5's reasoning_config), an actual tool-call round-trip for the 3 new tools, real-terminal confirmation-prompt UX inspection
+
+## Unit 8 / INITIATIVE 3 BUILD AND TEST: COMPLETE AND APPROVED (pending final sign-off)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -296,6 +296,12 @@ a verified ancestor of the merge commit before reset).
   - Manual verification via real components (Registry+tools+InteractivePermissionGate+ApprovalStore, scripted stdin, no AWS needed): approve-once creates file, deny blocks it cleanly, session approval correctly skips re-prompting for a matching run_shell call, git_diff never touches the gate.
   - cmd 33.3%->33.1% (negligible), tools 84.1%->81.9%, utils 53.7%->55.0%, total 69.7%->71.2%, no regressions. 7/7 integration tests pass.
 
-## Unit 7 Status: COMPLETE, AWAITING APPROVAL
+## Unit 7 Status: COMPLETE AND APPROVED (commit cd080a4)
 
+### Construction Phase - Unit 8 (Automatic Tool-Use Enablement, #86) - FINAL UNIT
+- [x] Functional Design + NFR - Completed 2026-07-08, awaiting user approval (combined presentation, lowest novelty of the 3 units - extends the already-tested cascading-retry pattern in cmd/inferenceconfig.go rather than introducing anything new)
+  - Artifacts: aidlc-docs/construction/unit-8-automatic-enablement/functional-design/business-logic-model.md, aidlc-docs/construction/unit-8-automatic-enablement/nfr-requirements/nfr-requirements-and-design.md
+  - Key finding: "disabled for the rest of the session" (FR1.2) falls out for free from the existing mutable converseStreamInput struct - no new session-state tracking needed. The FR1.3 user notice reuses the existing log.Printf convention already used by the cache/sampling-params fallbacks.
+  - **CAVEAT (same category as Unit 5's reasoning_config)**: isToolUseUnsupportedError's exact string-matching heuristic is UNVERIFIED against real Bedrock error text - added to the real-credential verification list.
+- [ ] Code Generation - Pending
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -289,5 +289,6 @@ a verified ancestor of the merge commit before reset).
   - Artifacts: aidlc-docs/construction/unit-7-new-tools/functional-design/{business-logic-model,business-rules,domain-entities}.md, aidlc-docs/construction/unit-7-new-tools/nfr-requirements/nfr-requirements-and-design.md
   - Key finding: utils.ValidateLocalPath requires the target file to already exist (existence check baked in) - wrong for write_file's create-new-file case. Resolved additively: new utils.ValidateLocalPathForWrite (confinement-only) sharing a private confineToWorkingDir helper with the unchanged, existing ValidateLocalPath - zero regression risk to Units 2/4's already-shipped call sites.
   - run_shell: 30s timeout, 32KB truncated combined output, non-zero exit code reported in output text (not a Go error) so the model sees command failures as normal operation, not tool bugs.
-- [ ] Code Generation - Pending
+- [x] Code Generation - Plan complete 2026-07-08, awaiting approval to begin generation
+  - Plan: aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md (10 TDD-ordered steps)
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -289,6 +289,13 @@ a verified ancestor of the merge commit before reset).
   - Artifacts: aidlc-docs/construction/unit-7-new-tools/functional-design/{business-logic-model,business-rules,domain-entities}.md, aidlc-docs/construction/unit-7-new-tools/nfr-requirements/nfr-requirements-and-design.md
   - Key finding: utils.ValidateLocalPath requires the target file to already exist (existence check baked in) - wrong for write_file's create-new-file case. Resolved additively: new utils.ValidateLocalPathForWrite (confinement-only) sharing a private confineToWorkingDir helper with the unchanged, existing ValidateLocalPath - zero regression risk to Units 2/4's already-shipped call sites.
   - run_shell: 30s timeout, 32KB truncated combined output, non-zero exit code reported in output text (not a Go error) so the model sees command failures as normal operation, not tool bugs.
-- [x] Code Generation - Plan complete 2026-07-08, awaiting approval to begin generation
-  - Plan: aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md (10 TDD-ordered steps)
+- [x] Code Generation - Completed 2026-07-08, awaiting user review/approval
+  - Plan: aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md (all 10 steps complete)
+  - Summary: aidlc-docs/construction/unit-7-new-tools/code/summary.md
+  - Real bug found+fixed during implementation: RunShellTool's timeout didn't bound wall-clock time for commands with grandchild processes (sh -c "sleep 5" - killing only sh left sleep running, holding the output pipe open). Fixed via process-group kill (Setpgid + syscall.Kill(-pid)). Caught by a "passing but suspiciously slow" test (5s instead of ~50ms).
+  - Manual verification via real components (Registry+tools+InteractivePermissionGate+ApprovalStore, scripted stdin, no AWS needed): approve-once creates file, deny blocks it cleanly, session approval correctly skips re-prompting for a matching run_shell call, git_diff never touches the gate.
+  - cmd 33.3%->33.1% (negligible), tools 84.1%->81.9%, utils 53.7%->55.0%, total 69.7%->71.2%, no regressions. 7/7 integration tests pass.
+
+## Unit 7 Status: COMPLETE, AWAITING APPROVAL
+
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -265,3 +265,11 @@ a verified ancestor of the merge commit before reset).
 - [x] Units Generation - Completed 2026-07-08, awaiting user approval - INCEPTION PHASE (Initiative 3) COMPLETE pending this approval
   - Artifacts: Initiative 3 sections appended to unit-of-work.md, unit-of-work-dependency.md, unit-of-work-story-map.md
   - 3 units: Unit 6 (Confirmation and Sticky Approval Engine, foundational), Unit 7 (New Built-in Tools, HARD dependency on Unit 6 - literally won't compile without it), Unit 8 (Automatic Tool-Use Enablement, soft dependency on 6+7). Build order: 6 -> 7 -> 8. All 8 stories assigned, 0 orphaned.
+
+## INCEPTION PHASE (Initiative 3) COMPLETE - entering CONSTRUCTION
+
+### Construction Phase - Unit 6 (Confirmation and Sticky Approval Engine, #86)
+- [x] Functional Design - Completed 2026-07-08, awaiting user approval
+  - Artifacts: aidlc-docs/construction/unit-6-confirmation-engine/functional-design/{business-logic-model,business-rules,domain-entities}.md
+  - Key decisions: NOT reusing utils.StringPrompt (wrong shape - bubbletea widget for free text vs. a discrete choice); ConfirmationSummary parse failure = denial-equivalent (never reaches gate); pattern keys are base-command (run_shell) / repo-relative directory (write_file); persisted store at <ConfigPath>/tool-approvals.yaml, 0600 perms, keyed by absolute repo root; InteractivePermissionGate takes injectable io.Reader/io.Writer for testability; "always" not offered outside a git repo (BR10)
+- [ ] NFR Requirements + Design - Pending

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -262,3 +262,6 @@ a verified ancestor of the merge commit before reset).
 - [x] Application Design - Completed 2026-07-08, awaiting user approval
   - Artifacts: Initiative 3 sections appended to aidlc-docs/inception/application-design/{components,component-methods,services,component-dependency,application-design}.md
   - Key design: extended `Tool` interface (RequiresConfirmation/ConfirmationSummary), 3 new tools, new `PermissionGate`/`ApprovalStore` (tools package) + `InteractivePermissionGate` (cmd package), `utils.FindGitBoundary` extracted from #88's private `findGitBoundary` to avoid a tools->cmd import cycle (the one change to already-shipped Initiative 2 code in this initiative, flagged explicitly)
+- [x] Units Generation - Completed 2026-07-08, awaiting user approval - INCEPTION PHASE (Initiative 3) COMPLETE pending this approval
+  - Artifacts: Initiative 3 sections appended to unit-of-work.md, unit-of-work-dependency.md, unit-of-work-story-map.md
+  - 3 units: Unit 6 (Confirmation and Sticky Approval Engine, foundational), Unit 7 (New Built-in Tools, HARD dependency on Unit 6 - literally won't compile without it), Unit 8 (Automatic Tool-Use Enablement, soft dependency on 6+7). Build order: 6 -> 7 -> 8. All 8 stories assigned, 0 orphaned.

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -275,5 +275,8 @@ a verified ancestor of the merge commit before reset).
 - [x] NFR Requirements + Design - Completed 2026-07-08, awaiting user approval (combined presentation, same pattern as Initiative 1 Units 2/4)
   - Artifacts: aidlc-docs/construction/unit-6-confirmation-engine/nfr-requirements/nfr-requirements-and-design.md
   - Security (dominant): Dispatch is the single choke point, fail-closed on every ambiguous state, per-repo scoping is a security boundary not just UX, 0600 file perms. Reliability: corrupted store degrades to empty (re-prompt), never fatal. Usability: informative prompts, stated truncation policy for large write_file content.
-- [ ] Infrastructure Design - SKIP (no infrastructure in this project)
-- [ ] Code Generation - Pending
+- [x] Infrastructure Design - SKIP (no infrastructure in this project)
+- [x] Code Generation - Plan complete 2026-07-08, awaiting approval to begin generation
+  - Plan: aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md (14 TDD-ordered steps)
+  - Key finding during planning: Registry.Dispatch has exactly one call site (cmd/toolloop.go's runChatTurnWithTools), which must have a gate threaded through all 4 of its own call sites to keep the tree compiling - Unit 6 constructs a real InteractivePermissionGate now (inert until Unit 7 adds destructive tools) rather than leaving intermediate commits broken
+- [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -259,3 +259,6 @@ a verified ancestor of the merge commit before reset).
 - [x] Workflow Planning - Completed 2026-07-08, awaiting user approval
   - Artifacts: aidlc-docs/inception/plans/builtin-tools-execution-plan.md
   - Risk: Medium-High (arbitrary shell exec, destructive writes). Application Design EXECUTE (new permission-engine architecture), Units Generation EXECUTE (multiple packages, new persisted state, complex pattern-matching - unlike Initiative 2's single natural unit). Per-unit Functional Design + NFR EXECUTE (Security now first-class). Infrastructure Design SKIP (unchanged global decision). Code Generation + Build and Test ALWAYS EXECUTE.
+- [x] Application Design - Completed 2026-07-08, awaiting user approval
+  - Artifacts: Initiative 3 sections appended to aidlc-docs/inception/application-design/{components,component-methods,services,component-dependency,application-design}.md
+  - Key design: extended `Tool` interface (RequiresConfirmation/ConfirmationSummary), 3 new tools, new `PermissionGate`/`ApprovalStore` (tools package) + `InteractivePermissionGate` (cmd package), `utils.FindGitBoundary` extracted from #88's private `findGitBoundary` to avoid a tools->cmd import cycle (the one change to already-shipped Initiative 2 code in this initiative, flagged explicitly)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -252,3 +252,7 @@ a verified ancestor of the merge commit before reset).
   - Artifacts: aidlc-docs/inception/requirements/builtin-tools-{questions,clarification-questions,requirements}.md
   - FR1-FR7 + NFR1-NFR5 documented. Notably revises Initiative 1's NFR1 (backward compatibility) by design - tool use becomes always-on with automatic graceful degradation, per explicit user direction
   - **Recommending User Stories EXECUTE (not skip)** this time - real UX/acceptance-criteria value given the new confirmation-gate/approval-tier interaction flows, unlike Initiative 2's simple flag/config plumbing
+- [x] User Stories - Completed 2026-07-08, awaiting user approval
+  - Assessment: aidlc-docs/inception/plans/builtin-tools-user-stories-assessment.md (EXECUTE)
+  - Plan: aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
+  - Artifacts: extended aidlc-docs/inception/user-stories/{personas.md,stories.md} in place (same persona, 3 new epics: 6 Automatic Enablement, 7 New Tools, 8 Confirmation/Sticky Approval; 8 stories total, full FR1-FR7 traceability)

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -220,4 +220,31 @@ No PR opened (not requested by user). Recommended before merge: run the
   - Build success, all unit/integration tests pass, no coverage regression, manual smoke test against the compiled binary confirmed discovery/--system-suppression/--no-context-file-suppression all work end-to-end. No new real-credential-verification surface (feature never touches Bedrock directly - reuses Initiative 1's existing system-prompt/cache-point pipeline as-is).
 
 ## Unit "agents-md-convention" Status: COMPLETE AND APPROVED (commit c1bb745)
-## INITIATIVE 2 STATUS: COMPLETE (pending final Build and Test approval)
+## INITIATIVE 2 STATUS: COMPLETE - PR #102 merged (commit 955130f on main), #88 closed
+
+### Initiative 2 Epilogue
+User tested the merged code and pushed one follow-up fix commit (768c9f1, with Cursor)
+before/at merge time: fixed a real bug where `resolveContextFilenames` couldn't
+distinguish "context-files config key unset" from "explicitly set to empty string" -
+both looked like the same empty input, so the documented disable-via-empty-config
+mechanism (FR5.2/BR12) silently didn't work. Fixed via a new `FileManager.IsConfigSet`
+plus a `configSet bool` parameter. Also improved notice/warning messages to show
+cwd-relative paths instead of full absolute paths, and hardened symlink handling.
+Branch `claude/ai-dlc-documentation-rl4e5s` reset to latest `origin/main` (955130f)
+to start Initiative 3 fresh; remote branch had been auto-deleted after merge, recreated
+via a plain push after `git remote prune origin` (confirmed safe: old branch head was
+a verified ancestor of the merge commit before reset).
+
+---
+
+# INITIATIVE 3: Built-in Agent Tools (#86)
+
+## Project Information
+- **Start Date**: 2026-07-08 (same day, continued session)
+- **Trigger**: User picked #86 next from the Group 2 (agentic direction) backlog after Initiative 2 (#88) merged.
+- **Scope per issue #86**: "Once tool use is supported [done, #82], add a small first-party toolset — read file [already done, #82], write file, run a shell command, git diff — so chat-cli chat can act as a lightweight, Bedrock-native coding assistant directly in the terminal... Needs careful scoping around confirmation prompts before destructive actions (file writes, shell exec)."
+- **Risk profile note**: Higher than Initiatives 1-2 - `run_shell` is arbitrary command execution, `write_file` is a destructive filesystem action. This will need real Security NFR treatment, not a skip, and likely a fuller Inception treatment (User Stories, possibly Application Design) given the confirmation-flow UX design surface.
+
+## Stage Progress
+- [x] Workspace Detection - Brownfield confirmed, reusing existing `aidlc-docs/aidlc-state.md` context (no re-run of Reverse Engineering - same rationale as Initiative 2, narrow addition to an already-understood `tools/` subsystem from Initiative 1 Unit 2)
+- [ ] Requirements Analysis - IN PROGRESS, clarifying questions issued

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -256,3 +256,6 @@ a verified ancestor of the merge commit before reset).
   - Assessment: aidlc-docs/inception/plans/builtin-tools-user-stories-assessment.md (EXECUTE)
   - Plan: aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
   - Artifacts: extended aidlc-docs/inception/user-stories/{personas.md,stories.md} in place (same persona, 3 new epics: 6 Automatic Enablement, 7 New Tools, 8 Confirmation/Sticky Approval; 8 stories total, full FR1-FR7 traceability)
+- [x] Workflow Planning - Completed 2026-07-08, awaiting user approval
+  - Artifacts: aidlc-docs/inception/plans/builtin-tools-execution-plan.md
+  - Risk: Medium-High (arbitrary shell exec, destructive writes). Application Design EXECUTE (new permission-engine architecture), Units Generation EXECUTE (multiple packages, new persisted state, complex pattern-matching - unlike Initiative 2's single natural unit). Per-unit Functional Design + NFR EXECUTE (Security now first-class). Infrastructure Design SKIP (unchanged global decision). Code Generation + Build and Test ALWAYS EXECUTE.

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -282,6 +282,9 @@ a verified ancestor of the merge commit before reset).
   - cmd 31.8%->33.3%, tools 90.0%->84.1%, utils 51.8%->53.7%, total 67.8%->69.7%, no regressions. 7/7 integration tests pass. No user-visible behavior change yet (by design) - gate fully wired but inert until Unit 7.
   - One caught-and-fixed deviation during implementation: persisted-entry format initially used the wrong (internal NUL-joined) key before being corrected to the documented human-readable "toolName:patternKey" format.
 
-## Unit 6 Status: COMPLETE, AWAITING APPROVAL
+## Unit 6 Status: COMPLETE AND APPROVED (commit 2e04ef0)
 
+### Construction Phase - Unit 7 (New Built-in Tools, #86)
+- [ ] Functional Design + NFR - Pending
+- [ ] Code Generation - Pending
 - [ ] Build and Test - Pending all 3 units

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -272,4 +272,8 @@ a verified ancestor of the merge commit before reset).
 - [x] Functional Design - Completed 2026-07-08, awaiting user approval
   - Artifacts: aidlc-docs/construction/unit-6-confirmation-engine/functional-design/{business-logic-model,business-rules,domain-entities}.md
   - Key decisions: NOT reusing utils.StringPrompt (wrong shape - bubbletea widget for free text vs. a discrete choice); ConfirmationSummary parse failure = denial-equivalent (never reaches gate); pattern keys are base-command (run_shell) / repo-relative directory (write_file); persisted store at <ConfigPath>/tool-approvals.yaml, 0600 perms, keyed by absolute repo root; InteractivePermissionGate takes injectable io.Reader/io.Writer for testability; "always" not offered outside a git repo (BR10)
-- [ ] NFR Requirements + Design - Pending
+- [x] NFR Requirements + Design - Completed 2026-07-08, awaiting user approval (combined presentation, same pattern as Initiative 1 Units 2/4)
+  - Artifacts: aidlc-docs/construction/unit-6-confirmation-engine/nfr-requirements/nfr-requirements-and-design.md
+  - Security (dominant): Dispatch is the single choke point, fail-closed on every ambiguous state, per-repo scoping is a security boundary not just UX, 0600 file perms. Reliability: corrupted store degrades to empty (re-prompt), never fatal. Usability: informative prompts, stated truncation policy for large write_file content.
+- [ ] Infrastructure Design - SKIP (no infrastructure in this project)
+- [ ] Code Generation - Pending

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -662,3 +662,10 @@
 **Context**: CONSTRUCTION PHASE, Unit 6 - Code Generation complete, awaiting approval before Unit 7 begins
 
 ---
+## Unit 6 - Approval
+**Timestamp**: 2026-07-08T18:37:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**Context**: Unit 6 (Confirmation and Sticky Approval Engine) approved and complete; Unit 7 (New Built-in Tools) begins next per build order
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -572,3 +572,17 @@
 **Context**: INCEPTION PHASE, Initiative 3 - User Stories complete, awaiting approval before Workflow Planning
 
 ---
+## User Stories - Approval (Initiative 3)
+**Timestamp**: 2026-07-08T17:07:00Z
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: User stories approved for #86; Workflow Planning begins
+
+---
+
+## Workflow Planning Complete (Initiative 3)
+**Timestamp**: 2026-07-08T17:12:00Z
+**AI Response**: Created execution plan for built-in agent tools. Risk assessed Medium-High given arbitrary shell execution and destructive file writes - the highest risk profile of any initiative so far. Recommends executing Application Design (the permission engine is genuinely new architecture, unlike Initiatives 1-2's pure-function additions) and Units Generation (multiple packages, new persisted state, complex pattern-matching logic - natural seams between automatic-enablement wiring, the permission engine, and the 3 new tools). Per-unit Functional Design + NFR to execute for every unit given Security is now a first-class concern. This is the most complete Inception/Construction treatment of any initiative to date (6 of 7 possible stages), proportional to the risk.
+**Context**: Workflow plan created with 6 stages to execute (Application Design, Units Generation, per-unit Functional Design+NFR, Code Generation, Build and Test) out of 7 possible
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -703,3 +703,11 @@
 **Context**: CONSTRUCTION PHASE - all 3 units complete, awaiting approval before initiative-wide Build and Test
 
 ---
+## Unit 8 - Approval; Initiative 3 Build and Test Complete
+**Timestamp**: 2026-07-08T19:40:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**AI Response**: Ran a fresh full verification pass across all 3 units together (make test/lint/coverage all green, no regressions across the whole initiative). Executed 4 cross-unit composition scenarios: combining Initiative 1's --system/--thinking with always-on tools; combining Initiative 2's --no-context-file with Initiative 3's always-on tools; the confirmation gate's full end-to-end behavior via real components (once/deny/session-reuse/read-only-tools-never-touch-the-gate); confirmed --tools is fully gone. Consolidated the real-credential verification list with this initiative's new unverified assumption (isToolUseUnsupportedError's heuristic, same risk category as Unit 5's reasoning_config from Initiative 1).
+**Context**: Build and Test stage, CONSTRUCTION phase - final stage of Initiative 3
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -697,3 +697,9 @@
 **Context**: CONSTRUCTION PHASE, Unit 8 (final unit) - Functional Design + NFR complete, awaiting approval before Code Generation
 
 ---
+## Unit 8 Code Generation Complete - ALL 3 UNITS OF INITIATIVE 3 CODE-COMPLETE
+**Timestamp**: 2026-07-08T19:30:00Z
+**AI Response**: Executed all 5 steps TDD-ordered. isToolUseUnsupportedError unit-tested directly (mirroring the existing isDeprecatedSamplingParamsError precedent); the new retry branch inside converseStreamWithFallbacks itself was not separately unit-tested, matching the established precedent that this function's other two fallback stages (cache points, sampling params) also have no direct tests since they call the real unmockable bedrockruntime.Client. Removed --tools entirely (verified via chat-cli --help). Manually verified via a real-components scratch driver that the registry always contains all 4 tools with no flag needed. Full verification green, no regressions. This completes Unit 6 -> Unit 7 -> Unit 8, all 3 units of Initiative 3 (#86) code-complete.
+**Context**: CONSTRUCTION PHASE - all 3 units complete, awaiting approval before initiative-wide Build and Test
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -628,3 +628,9 @@
 **Context**: CONSTRUCTION PHASE, Unit 6 - Functional Design complete, awaiting approval before NFR Requirements + Design
 
 ---
+## Unit 6 NFR Requirements + Design Complete
+**Timestamp**: 2026-07-08T17:55:00Z
+**AI Response**: Combined NFR presentation (Security dominant, Reliability + Usability secondary, Scalability/Performance/Availability N/A per established project-wide rationale). Key security design: Registry.Dispatch as the single choke point (structurally enforced by the interface, not just convention), fail-closed on every ambiguous state (unparseable summary, unrecognized prompt input, corrupted store all resolve to deny/re-prompt, never allow), per-repository scoping treated as a real security boundary with a dedicated Build and Test scenario planned to verify it, 0600 file permissions on the persisted store.
+**Context**: CONSTRUCTION PHASE, Unit 6 - NFR complete, awaiting approval before Code Generation
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -614,3 +614,17 @@
 **Context**: INCEPTION PHASE COMPLETE for Initiative 3, awaiting approval to enter CONSTRUCTION PHASE
 
 ---
+## Units Generation - Approval (Initiative 3)
+**Timestamp**: 2026-07-08T17:37:00Z
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: Units approved for #86; CONSTRUCTION phase begins, Unit 6 first per build order
+
+---
+
+## Unit 6 Functional Design Complete
+**Timestamp**: 2026-07-08T17:48:00Z
+**AI Response**: Designed the confirmation gate directly (verified against real tools/registry.go, utils/utils.go, config/config.go source). Deliberately did not reuse utils.StringPrompt (bubbletea free-text widget, wrong shape for a discrete once/session/always/deny choice, harder to test) - designed a minimal injectable-reader/writer prompt instead. Made ConfirmationSummary parse failure fail-closed as a denial before the gate is ever consulted. Designed the persisted approval store (YAML, <ConfigPath>/tool-approvals.yaml, 0600, keyed by absolute repo root) and pattern-key derivation rules (base command for run_shell, repo-relative directory for write_file). 15 business rules documented, including the not-in-a-repo edge case (BR10: "always" not offered outside a git repo).
+**Context**: CONSTRUCTION PHASE, Unit 6 - Functional Design complete, awaiting approval before NFR Requirements + Design
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -683,3 +683,9 @@
 **Context**: CONSTRUCTION PHASE, Unit 7 - Code Generation Part 1 (Planning) complete, awaiting approval to begin generation
 
 ---
+## Unit 7 Code Generation Complete
+**Timestamp**: 2026-07-08T19:10:00Z
+**AI Response**: Executed all 10 steps TDD-ordered. Found and fixed a real reliability bug not caught by functional design: RunShellTool's timeout used exec.CommandContext, which only kills the direct child (sh) - a grandchild process (sleep, spawned via sh -c) kept running and holding the output pipe open, so Execute didn't actually return until the full command duration elapsed regardless of the configured timeout. Caught via a "test passes but takes 5s instead of ~50ms" signal. Fixed with process-group kill (Setpgid + syscall.Kill(-pid, SIGKILL)), racing the blocking CombinedOutput() call against ctx.Done(). Verified the fix drops the affected test from 5.02s to 0.066s, and strengthened the test to assert prompt return time going forward, not just eventual correctness. Manually verified the full wiring end-to-end using real components (no AWS needed) since a live model can't be driven to request tool calls in this environment: approve-once/deny/session-approval-reuse/gate-never-consulted-for-read-only-tools all confirmed working through the actual Registry.Dispatch + InteractivePermissionGate + ApprovalStore code path chat.go uses.
+**Context**: CONSTRUCTION PHASE, Unit 7 - Code Generation complete, awaiting approval before Unit 8
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -530,3 +530,18 @@
 **Context**: CONSTRUCTION PHASE, agents-md-convention unit - Build and Test complete, awaiting final approval
 
 ---
+## Initiative 2 Epilogue: PR Merged, Follow-up Fix Noticed
+**Timestamp**: 2026-07-08T16:35:00Z
+**User Input**: "I've merged the PR and tested the code."
+**AI Response**: Noted PR #102 merged (commit 955130f) with an extra fix commit (768c9f1) the user pushed after testing - fixed a real bug in resolveContextFilenames (couldn't distinguish unset vs. explicitly-empty context-files config, breaking the documented disable mechanism) plus display-path/symlink improvements. Acknowledged the good catch.
+**Context**: Initiative 2 (#88) fully complete and merged
+
+---
+
+## Initiative 3 Kickoff: Built-in Agent Tools (#86)
+**Timestamp**: 2026-07-08T16:38:00Z
+**User Input**: "Let's work on 86 built in tools next"
+**AI Response**: Reset branch claude/ai-dlc-documentation-rl4e5s to latest origin/main (955130f) per merged-branch protocol - remote branch had been auto-deleted after PR #102 merged, recreated via plain push after pruning stale remote-tracking refs (verified old branch head was a confirmed ancestor of main before reset, so no work was lost). Workspace Detection: brownfield, reusing existing context, no Reverse Engineering re-run (same rationale as Initiative 2). Flagged this initiative's higher risk profile (run_shell = arbitrary command execution, write_file = destructive filesystem action) as likely warranting fuller Inception treatment than Initiatives 1-2. Requirements Analysis clarifying questions issued next.
+**Context**: INCEPTION PHASE, Initiative 3 - Workspace Detection complete, entering Requirements Analysis
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -648,3 +648,17 @@
 **Context**: CONSTRUCTION PHASE, Unit 6 - Code Generation Part 1 (Planning) complete, awaiting approval
 
 ---
+## Unit 6 Code Generation Plan - Approval
+**Timestamp**: 2026-07-08T18:07:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**Context**: Plan approved for Unit 6; Code Generation Part 2 (Generation) begins
+
+---
+
+## Unit 6 Code Generation Complete
+**Timestamp**: 2026-07-08T18:35:00Z
+**AI Response**: Executed all 14 steps TDD-ordered (red confirmed via go vet before each implementation). Go's whole-package compilation forced Steps 11-13 together (writing the InteractivePermissionGate test couldn't compile in isolation once Dispatch's signature changed in Step 10) - completed them together while preserving red/green discipline per-function. Caught and fixed one real deviation from the functional design during implementation: the persisted approval-store format initially used the internal NUL-joined key instead of the documented human-readable "toolName:patternKey" format - fixed before any test was written against the wrong format. Full verification: make test/lint/coverage all pass with no regressions, 7/7 integration tests pass. Confirmed no user-visible behavior change yet, by design - the gate is fully wired end-to-end but inert since read_file (the only registered tool) is non-destructive.
+**Context**: CONSTRUCTION PHASE, Unit 6 - Code Generation complete, awaiting approval before Unit 7 begins
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -545,3 +545,10 @@
 **Context**: INCEPTION PHASE, Initiative 3 - Workspace Detection complete, entering Requirements Analysis
 
 ---
+## Requirements Analysis Round 2 + Completion (Initiative 3)
+**Timestamp**: 2026-07-08T16:50:00Z
+**User Input**: Round 1 freeform summary ("tools should just work, no flags... all commands/tools should require a confirm with option to be sticky for the session... scopes should use a pattern like curl/*/*..."), then round-2 answers: "1. Destructive only 2. Coarse 3. User should be able to select - this session, always, once 4. No we don't need this.. the models that don't support tools should automatically turn off tools and let the user know"
+**AI Response**: Recognized the round-1 answer expanded scope beyond issue #86's literal text (revises Initiative 1's --tools opt-in design) and asked 4 targeted follow-ups rather than guessing given the security stakes. Wrote builtin-tools-requirements.md: FR1 automatic tool-use enablement with retry-without-tools-on-rejection (mirroring #83's cache retry pattern) and a user-visible notice; FR2-4 the three new tools (write_file, run_shell, git_diff); FR5-6 a destructive-only confirmation gate with three-tier (once/session/always) coarse pattern-based sticky approval (base-command for run_shell, directory for write_file); FR7 per-repository persisted storage for "always" approvals. Recommending User Stories EXECUTE (not skip) given real UX design value, departing from Initiative 2's skip.
+**Context**: INCEPTION PHASE, Initiative 3 - Requirements Analysis complete, awaiting approval
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -552,3 +552,9 @@
 **Context**: INCEPTION PHASE, Initiative 3 - Requirements Analysis complete, awaiting approval
 
 ---
+## User Stories Plan - Approval Prompt (Initiative 3)
+**Timestamp**: 2026-07-08T16:55:00Z
+**AI Prompt**: "Approve the User Stories approach (assessment + plan) and proceed to generation?"
+**Context**: Assessment recommends EXECUTE (departing from Initiative 2's skip) given the confirmation/approval system's multiple distinct interaction scenarios. Plan reuses the existing single persona (extended) and Initiative 1's feature-based/Given-When-Then story format, methodology decisions stated as assumptions rather than a second Q&A round.
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -669,3 +669,9 @@
 **Context**: Unit 6 (Confirmation and Sticky Approval Engine) approved and complete; Unit 7 (New Built-in Tools) begins next per build order
 
 ---
+## Unit 7 Functional Design + NFR Complete
+**Timestamp**: 2026-07-08T18:45:00Z
+**AI Response**: Combined presentation (lower novelty than Unit 6 - applies its established gate pattern to 3 mechanical tools rather than introducing new architecture). Found and resolved a real gap during design: utils.ValidateLocalPath requires the target file to already exist, which is wrong for write_file's create-new-file requirement (FR2.2). Resolved additively - a new ValidateLocalPathForWrite (confinement-only) shares a private confineToWorkingDir helper with the unchanged existing ValidateLocalPath, zero regression risk to Units 2/4. Designed run_shell's exit-code handling deliberately: non-zero exit is normal tool output (visible to the model), not a Go error, distinct from timeout/start-failure which are real errors. git_diff passes its optional arg as a single exec.Command argument (not shell-concatenated) for both security and reliability.
+**Context**: CONSTRUCTION PHASE, Unit 7 - Functional Design + NFR complete, awaiting approval before Code Generation
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -600,3 +600,17 @@
 **Context**: INCEPTION PHASE, Initiative 3 - Application Design complete, awaiting approval before Units Generation
 
 ---
+## Application Design - Approval (Initiative 3)
+**Timestamp**: 2026-07-08T17:27:00Z
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: Application design approved for #86; Units Generation begins
+
+---
+
+## Units Generation Complete (Initiative 3)
+**Timestamp**: 2026-07-08T17:35:00Z
+**AI Response**: Decomposed into 3 units directly from the approved Application Design (no additional Q&A round needed - the component design already made the seams clear): Unit 6 (Confirmation and Sticky Approval Engine - foundational, extended Tool interface + PermissionGate + ApprovalStore + InteractivePermissionGate + utils.FindGitBoundary extraction), Unit 7 (New Built-in Tools - write_file/run_shell/git_diff, with a HARD compile-time dependency on Unit 6 unlike every other soft dependency in this session's work so far), Unit 8 (Automatic Tool-Use Enablement - --tools removal, retry-without-tools wrapper). Build order 6->7->8. All 8 stories mapped, 0 orphaned.
+**Context**: INCEPTION PHASE COMPLETE for Initiative 3, awaiting approval to enter CONSTRUCTION PHASE
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -675,3 +675,11 @@
 **Context**: CONSTRUCTION PHASE, Unit 7 - Functional Design + NFR complete, awaiting approval before Code Generation
 
 ---
+## Unit 7 - Functional Design + NFR Approval, Code Generation Plan Created
+**Timestamp**: 2026-07-08T18:50:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**AI Response**: Created a 10-step TDD-ordered plan. Key testability decision: RunShellTool's timeout is an unexported struct field (default 30s) rather than a hardcoded constant, so tests can inject a short timeout instead of waiting 30 real seconds.
+**Context**: CONSTRUCTION PHASE, Unit 7 - Code Generation Part 1 (Planning) complete, awaiting approval to begin generation
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -558,3 +558,17 @@
 **Context**: Assessment recommends EXECUTE (departing from Initiative 2's skip) given the confirmation/approval system's multiple distinct interaction scenarios. Plan reuses the existing single persona (extended) and Initiative 1's feature-based/Given-When-Then story format, methodology decisions stated as assumptions rather than a second Q&A round.
 
 ---
+## User Stories Plan - Approval (Initiative 3)
+**Timestamp**: 2026-07-08T17:00:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**Context**: Story generation plan approved; Part 2 (Generation) begins
+
+---
+
+## User Stories Complete (Initiative 3)
+**Timestamp**: 2026-07-08T17:05:00Z
+**AI Response**: Extended personas.md (same single persona, additive goals/pain-points for this initiative) and stories.md (3 new epics, 8 stories, full FR1-FR7 traceability) covering automatic tool-use enablement with graceful degradation, the 3 new tools, and the confirmation/sticky-approval system including both unhappy paths (denial, auto-disable-on-rejection) as their own stories per the assessment's stated reasoning.
+**Context**: INCEPTION PHASE, Initiative 3 - User Stories complete, awaiting approval before Workflow Planning
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -634,3 +634,17 @@
 **Context**: CONSTRUCTION PHASE, Unit 6 - NFR complete, awaiting approval before Code Generation
 
 ---
+## Unit 6 NFR - Approval
+**Timestamp**: 2026-07-08T17:58:00Z
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: NFR approved for Unit 6; Code Generation Part 1 (Planning) begins
+
+---
+
+## Unit 6 Code Generation Plan Created
+**Timestamp**: 2026-07-08T18:05:00Z
+**AI Response**: Created a 14-step TDD-ordered plan. Key finding during planning (not assumed, verified against real cmd/toolloop.go source): Registry.Dispatch has exactly one call site (runChatTurnWithTools in cmd/toolloop.go), which has 4 of its own call sites (2 in chat.go, 2 in toolturn_test.go) - changing Dispatch's signature requires threading a gate through all of them to keep the tree compiling, since --tools/registry wiring isn't removed until Unit 8. Decided to construct a real InteractivePermissionGate now (Step 13) rather than a stub, so every intermediate commit stays fully correct, not just compiling - it's inert in practice until Unit 7 adds destructive tools.
+**Context**: CONSTRUCTION PHASE, Unit 6 - Code Generation Part 1 (Planning) complete, awaiting approval
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -689,3 +689,11 @@
 **Context**: CONSTRUCTION PHASE, Unit 7 - Code Generation complete, awaiting approval before Unit 8
 
 ---
+## Unit 7 - Approval, Unit 8 Functional Design + NFR Complete
+**Timestamp**: 2026-07-08T19:15:00Z
+**User Response**: "Approved"
+**Status**: Approved
+**AI Response**: Designed Unit 8 directly, verified against the actual cmd/inferenceconfig.go source. Found that converseStreamWithFallbacks already implements exactly this shape of cascading-retry logic twice (cache points, deprecated sampling params) - added tool-use rejection as a third stage in the same function, reusing its existing conventions. Found that FR1.2's "disabled for the rest of the session" requirement falls out for free from the existing mutable converseStreamInput struct reused across turns - no new state needed. Flagged isToolUseUnsupportedError's string-matching heuristic as unverified against real Bedrock error text, same category of risk as Unit 5's reasoning_config shape from Initiative 1.
+**Context**: CONSTRUCTION PHASE, Unit 8 (final unit) - Functional Design + NFR complete, awaiting approval before Code Generation
+
+---

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -586,3 +586,17 @@
 **Context**: Workflow plan created with 6 stages to execute (Application Design, Units Generation, per-unit Functional Design+NFR, Code Generation, Build and Test) out of 7 possible
 
 ---
+## Workflow Planning - Approval (Initiative 3)
+**Timestamp**: 2026-07-08T17:14:00Z
+**User Response**: "Approve"
+**Status**: Approved
+**Context**: Execution plan approved for #86; Application Design begins
+
+---
+
+## Application Design Complete (Initiative 3)
+**Timestamp**: 2026-07-08T17:25:00Z
+**AI Response**: Designed directly (verified against current tools/tool.go, tools/registry.go source) rather than another Q&A round, given how much was already resolved across two Requirements Analysis rounds. Key decisions: extend the Tool interface with RequiresConfirmation/ConfirmationSummary rather than a separate registry-side lookup table; new PermissionGate interface + ApprovalStore (tools package, pure logic) + InteractivePermissionGate (cmd package, owns terminal I/O) mirroring the existing tools/cmd split from Unit 2; Registry.Dispatch signature extended to accept a PermissionGate. Found and resolved a real import-cycle risk: ApprovalStore needs #88's git-boundary-detection logic, but tools cannot import cmd - resolved by extracting utils.FindGitBoundary and refactoring cmd/projectcontext.go to use it, the one change to already-shipped Initiative 2 code in this initiative.
+**Context**: INCEPTION PHASE, Initiative 3 - Application Design complete, awaiting approval before Units Generation
+
+---

--- a/aidlc-docs/construction/build-and-test/builtin-tools-summary.md
+++ b/aidlc-docs/construction/build-and-test/builtin-tools-summary.md
@@ -1,0 +1,61 @@
+# Build and Test Summary: Built-in Agent Tools (#86)
+
+Covers all 3 units together: Unit 6 (Confirmation and Sticky Approval Engine), Unit 7 (New Built-in Tools), Unit 8 (Automatic Tool-Use Enablement).
+
+## Build Status
+- **Build Tool**: Go 1.24+ (`go build`/`make cli`)
+- **Build Status**: Success — `go build ./...` clean, no warnings
+- **Build Artifacts**: `./bin/chat-cli` (built and verified, then removed per repo convention)
+
+## Unit Tests
+- **Command**: `make test`
+- **Result**: All packages pass, 0 failures (2 pre-existing `SKIP`s unrelated to this initiative)
+- **Coverage**: `cmd` 31.8%→33.5%, `tools` 90.0%→81.9% (new package surface added, still high), `utils` 51.8%→55.0%, total 67.8%→70.9% — no regression across the initiative
+- **New test files this initiative**: `tools/approvalstore_test.go`, `tools/writefile_test.go`, `tools/runshell_test.go`, `tools/gitdiff_test.go`, `cmd/permissionprompt_test.go`, plus extensions to `tools/readfile_test.go`, `tools/registry_test.go`, `utils/utils_test.go`, `cmd/inferenceconfig_test.go`, `cmd/toolturn_test.go`
+
+## Integration Tests
+- **Command**: `make cli && go test -tags=integration -v .`
+- **Result**: 7/7 pass, including `TestCLIFlagsExist` (confirms `--tools` is gone, no new flag was added by this initiative — the whole point was removing a flag)
+
+## Cross-Unit Composition Scenarios
+Since no AWS credentials are available in this environment, these verify wiring composes correctly up to the AWS-credentials boundary, plus (for the security-relevant confirmation gate specifically) full end-to-end verification via real components without needing a live model.
+
+### Scenario 1: `chat` with `--system` + `--thinking` + always-on tools combined
+- **Test**: `chat-cli --system "test" --thinking --thinking-budget 2048`
+- **Result**: ✅ Pass — session starts cleanly, tools silently attached (all 4, no flag), no panic.
+
+### Scenario 2: `chat` with `--no-context-file` (#88) + always-on tools (#86) combined
+- **Test**: `chat-cli --no-context-file`
+- **Result**: ✅ Pass — confirms Initiative 2 and Initiative 3's features coexist without interference.
+
+### Scenario 3: Confirmation gate, full end-to-end, real components (no AWS needed)
+Since driving a live model into requesting a tool call isn't possible here, this scenario wires the real `Registry`, real tools, and real `InteractivePermissionGate`/`ApprovalStore` together with scripted stdin — the exact code path `chat.go` uses once a model does request a tool call:
+1. `write_file` + approve **once** → file created with correct content, `Dispatch` returns success
+2. `write_file` + **deny** → file NOT created, model receives an error `ToolResultBlock`, no crash
+3. `run_shell` + approve **session** → first call prompts; a second call with the same base command (`echo`) skips the prompt entirely — session-tier sticky approval verified working
+4. `git_diff` with no stdin available at all → reached and errored immediately (correctly, not a git repo) without ever attempting to read from stdin — confirms the gate is never consulted for non-destructive tools
+- **Result**: ✅ Pass, all 4 sub-scenarios (see Unit 7's code summary for the original run)
+
+### Scenario 4: `--tools` fully removed
+- **Test**: `chat-cli --help | grep -i tools`
+- **Result**: ✅ Pass — zero matches, confirming Unit 8's flag removal is complete.
+
+## Security Verification
+- Per-repository "always" approval isolation (the security-critical property from FR7.1 — an approval in one repo must never leak into another) is verified at the unit level in `tools/approvalstore_test.go`'s `TestApprovalStore_AlwaysTier/always_approvals_do_not_leak_across_different_repository_roots` subtest, using two real `ApprovalStore` instances pointed at different repo roots sharing the same config path.
+- `write_file`'s cwd confinement reuses `utils.ValidateLocalPathForWrite`, itself sharing the same `confineToWorkingDir` core logic already proven by `utils.ValidateLocalPath`'s existing, unmodified test suite.
+- `run_shell`'s process-group-kill fix (found during Unit 7) is covered by a test that asserts both correctness and prompt return time, so the "timeout doesn't actually bound wall-clock time" regression class can't silently return.
+
+## Performance Tests
+- **Status**: N/A — same rationale as every prior initiative (single-user local CLI). `run_shell`'s 30s timeout is a reliability bound, not a performance target.
+
+## ⚠️ Consolidated Real-Credential Verification List (this initiative's additions)
+No AWS credentials are available in this environment. New items added to the project's running list (alongside Initiative 1's pre-existing items, most notably Unit 5's `reasoning_config` shape):
+
+1. **`isToolUseUnsupportedError`'s heuristic** (Unit 8) — unverified against real Bedrock error text for a tool-use rejection. Same risk category and same open question as Unit 5's `reasoning_config` shape. If a model that doesn't support tools breaks `chat` instead of gracefully falling back, check this first.
+2. **An actual tool-call round-trip for the 3 new tools** (Unit 7) — the protocol and gate logic are fully verified against synthetic events and real local components, but never against a real model's actual tool-call behavior for `write_file`/`run_shell`/`git_diff` specifically (Unit 2's `read_file` round-trip from Initiative 1 is a separate, still-open item on the original list).
+3. **Real-world confirmation prompt UX** — the prompt text/formatting has been verified programmatically (captured buffer content) but never visually inspected in a real terminal session.
+
+## Overall Status
+- **Build**: ✅ Success
+- **All Tests**: ✅ Pass (unit + integration + cross-unit composition + security verification; performance N/A)
+- **Ready for**: Merge. All 3 units of #86 are code-complete, individually and cross-unit tested, committed, and pushed to `claude/ai-dlc-documentation-rl4e5s`.

--- a/aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md
@@ -1,0 +1,52 @@
+# Code Generation Plan: Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+## Unit Context
+- **Stories**: 8.1-8.3 (FR5.1-FR5.4, FR6.1-FR6.3, FR7.1-FR7.2)
+- **Design source**: `aidlc-docs/construction/unit-6-confirmation-engine/functional-design/`, `.../nfr-requirements/nfr-requirements-and-design.md`
+- **Dependencies**: None (foundational unit)
+- **Verified call-site reality** (not assumed): `tools.Registry.Dispatch` is currently called from exactly one place, `cmd/toolloop.go:205` inside `runChatTurnWithTools`, which itself is called from `cmd/chat.go` (2 call sites) and `cmd/toolturn_test.go` (2 call sites). Changing `Dispatch`'s signature means `runChatTurnWithTools` needs a new `gate tools.PermissionGate` parameter too, threaded through all 4 call sites - this unit must leave the tree fully compiling and green, not just add new files, since `--tools`/registry wiring isn't removed until Unit 8.
+- **Design choice for this unit's call-site update**: construct a real `InteractivePermissionGate` (backed by a real `ApprovalStore`) at the existing registry-construction point in `chat.go`, rather than a stub/nil gate. Currently inert in practice - the only registered tool (`read_file`) has `RequiresConfirmation() == false`, so the gate is never actually consulted until Unit 7 adds destructive tools - but this keeps every intermediate commit's behavior fully correct, not just compiling.
+
+## Steps
+
+- [ ] **Step 1 - Failing test: extended `Tool` interface on `ReadFileTool`**
+  Add `TestReadFileTool_RequiresConfirmation` to `tools/readfile_test.go` asserting `RequiresConfirmation() == false`. Run `go test ./tools/... -run TestReadFileTool_RequiresConfirmation`, confirm compile failure (method doesn't exist).
+
+- [ ] **Step 2 - Extend `Tool` interface + implement on `ReadFileTool`**
+  Add `RequiresConfirmation() bool` and `ConfirmationSummary(input json.RawMessage) (summary, patternKey string, err error)` to `tools/tool.go`'s `Tool` interface. Implement on `ReadFileTool` (`RequiresConfirmation` returns `false`; `ConfirmationSummary` returns empty values, never called in practice per BR5). Update any fake `Tool` implementations in `tools/registry_test.go` to satisfy the extended interface (check current fakes first). Run Step 1's test, confirm green; run full `tools` package tests, confirm no regressions.
+
+- [ ] **Step 3 - Failing tests: `Decision`/`PermissionGate`/`ApprovalStore` session tier**
+  Create `tools/approvalstore_test.go` with cases for BR6-BR9's session-tier behavior: `IsApproved` false before any record; true after `RecordSession`; independent per `toolName+patternKey` pair (approving `run_shell:git` doesn't approve `run_shell:npm` or `write_file:git`). Confirm compile failure.
+
+- [ ] **Step 4 - Implement `Decision`, `PermissionGate`, `ApprovalStore` session tier**
+  Create `tools/permission.go` (`Decision` type + constants, `PermissionGate` interface). Create `tools/approvalstore.go` with `ApprovalStore` struct (session tier only for now - `map[string]bool` keyed per the `\x00`-joined key from `business-logic-model.md`), `NewApprovalStore`, `IsApproved`, `RecordSession`. Run Step 3 tests, confirm green.
+
+- [ ] **Step 5 - Failing tests: `ApprovalStore` persisted "always" tier**
+  Add cases to `approvalstore_test.go` using `t.TempDir()` for a fake `ConfigPath`: `RecordAlways` writes to `<path>/tool-approvals.yaml` with `0600` perms (BR14); a fresh `NewApprovalStore` pointed at that path loads the prior "always" approval (`IsApproved` returns true without a `RecordSession` call); different repo roots don't see each other's "always" approvals (FR7.1, the security-critical case flagged in NFR); a missing or malformed YAML file at construction yields zero approvals, not an error (BR15); `RecordAlways` is a safe no-op when `repoRoot == ""` (BR10's "not in a repo" case). Confirm compile failure.
+
+- [ ] **Step 6 - Implement `ApprovalStore` persisted tier**
+  Add YAML load/save (`gopkg.in/yaml.v3`, already a dependency per `cmd/config.go`), `RecordAlways`, the repo-root-keyed structure from `business-logic-model.md`. Run Step 5 tests, confirm green.
+
+- [ ] **Step 7 - Failing tests: `utils.FindGitBoundary`**
+  Add `TestFindGitBoundary` to `utils/utils_test.go`, porting the exact scenarios `cmd/projectcontext_test.go`'s existing boundary-related subtests already cover (match at cwd's own `.git`, match at a nested-parent's `.git`, no `.git` anywhere returns `""`, capped walk) so the extracted function is proven equivalent before the extraction happens. Confirm compile failure (function doesn't exist yet in `utils`).
+
+- [ ] **Step 8 - Extract `utils.FindGitBoundary`, refactor `cmd/projectcontext.go`**
+  Add `FindGitBoundary(dir string) string` to `utils/utils.go` (identical body to `cmd/projectcontext.go`'s current private `findGitBoundary`, including the 64-level cap). Delete the private copy in `cmd/projectcontext.go` and replace its one call site with `utils.FindGitBoundary(...)`. Run Step 7's new tests plus the full existing `cmd/projectcontext_test.go` suite unmodified, confirm all green (this proves the extraction preserved behavior exactly - #88's existing tests are the regression net).
+
+- [ ] **Step 9 - Failing tests: `Registry.Dispatch` gate-consulting behavior**
+  Add cases to `tools/registry_test.go` using fake `Tool`/`PermissionGate` implementations: a non-destructive tool's `Execute` is called without ever touching the gate (BR5); a destructive tool with a `ConfirmationSummary` error returns an error `ToolResultBlock` without calling the gate or `Execute` (BR3-BR4); a gate returning `DecisionDeny` returns a declined-error `ToolResultBlock` without calling `Execute` (BR11); a gate returning any Allow variant calls `Execute` and returns its result. Confirm compile failure (signature doesn't match yet).
+
+- [ ] **Step 10 - Implement `Registry.Dispatch`'s extended signature**
+  Change `Dispatch(ctx, call, gate PermissionGate) types.ToolResultBlock`, insert the gate-consulting logic from `business-logic-model.md`'s data-flow section. Run Step 9 tests, confirm green.
+
+- [ ] **Step 11 - Failing tests: `InteractivePermissionGate` prompt parsing**
+  Create `cmd/permissionprompt_test.go` with cases using injected `strings.Reader`/`bytes.Buffer` (per Application Design's testability decision): each of `o`/`s`/`a`/`n` (case-insensitive) parses to the right `Decision`; empty input/EOF/unrecognized input defaults to deny (BR12); a session choice calls `store.RecordSession`; an always choice calls `store.RecordAlways` only when a repo root is available, and "always" isn't even offered in the prompt text when it isn't (BR10). Confirm compile failure.
+
+- [ ] **Step 12 - Implement `InteractivePermissionGate`**
+  Create `cmd/permissionprompt.go` per `domain-entities.md`'s shape. Run Step 11 tests, confirm green.
+
+- [ ] **Step 13 - Thread the gate through `runChatTurnWithTools` and its call sites**
+  Add a `gate tools.PermissionGate` parameter to `runChatTurnWithTools` (`cmd/toolloop.go`), pass it through to the `registry.Dispatch(ctx, call, gate)` call. Update `cmd/chat.go`'s registry-construction block: build an `ApprovalStore` (via `os.Getwd()` + `utils.FindGitBoundary` + `fm.ConfigPath`) and an `InteractivePermissionGate` (`os.Stdin`/`os.Stdout`) alongside the existing `registry := tools.NewRegistry()` line, pass `gate` into both `runChatTurnWithTools` call sites. Update `cmd/toolturn_test.go`'s 2 call sites with a no-op fake gate (mirroring how `onReasoning` no-op callbacks were added in Initiative 1 Unit 5).
+
+- [ ] **Step 14 - Full verification**
+  `make test`, `make lint`, `make test-coverage` (confirm no regression in `tools`/`cmd`/`utils`), `make cli && go test -tags=integration -v .`. No behavior change expected yet from a user's perspective (`read_file` is still the only registered tool, still non-destructive, still `--tools`-gated) - this step confirms the plumbing is correct and inert, ready for Unit 7 to actually exercise it.

--- a/aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/unit-6-confirmation-engine-code-generation-plan.md
@@ -9,44 +9,44 @@
 
 ## Steps
 
-- [ ] **Step 1 - Failing test: extended `Tool` interface on `ReadFileTool`**
+- [x] **Step 1 - Failing test: extended `Tool` interface on `ReadFileTool`**
   Add `TestReadFileTool_RequiresConfirmation` to `tools/readfile_test.go` asserting `RequiresConfirmation() == false`. Run `go test ./tools/... -run TestReadFileTool_RequiresConfirmation`, confirm compile failure (method doesn't exist).
 
-- [ ] **Step 2 - Extend `Tool` interface + implement on `ReadFileTool`**
+- [x] **Step 2 - Extend `Tool` interface + implement on `ReadFileTool`**
   Add `RequiresConfirmation() bool` and `ConfirmationSummary(input json.RawMessage) (summary, patternKey string, err error)` to `tools/tool.go`'s `Tool` interface. Implement on `ReadFileTool` (`RequiresConfirmation` returns `false`; `ConfirmationSummary` returns empty values, never called in practice per BR5). Update any fake `Tool` implementations in `tools/registry_test.go` to satisfy the extended interface (check current fakes first). Run Step 1's test, confirm green; run full `tools` package tests, confirm no regressions.
 
-- [ ] **Step 3 - Failing tests: `Decision`/`PermissionGate`/`ApprovalStore` session tier**
+- [x] **Step 3 - Failing tests: `Decision`/`PermissionGate`/`ApprovalStore` session tier**
   Create `tools/approvalstore_test.go` with cases for BR6-BR9's session-tier behavior: `IsApproved` false before any record; true after `RecordSession`; independent per `toolName+patternKey` pair (approving `run_shell:git` doesn't approve `run_shell:npm` or `write_file:git`). Confirm compile failure.
 
-- [ ] **Step 4 - Implement `Decision`, `PermissionGate`, `ApprovalStore` session tier**
+- [x] **Step 4 - Implement `Decision`, `PermissionGate`, `ApprovalStore` session tier**
   Create `tools/permission.go` (`Decision` type + constants, `PermissionGate` interface). Create `tools/approvalstore.go` with `ApprovalStore` struct (session tier only for now - `map[string]bool` keyed per the `\x00`-joined key from `business-logic-model.md`), `NewApprovalStore`, `IsApproved`, `RecordSession`. Run Step 3 tests, confirm green.
 
-- [ ] **Step 5 - Failing tests: `ApprovalStore` persisted "always" tier**
+- [x] **Step 5 - Failing tests: `ApprovalStore` persisted "always" tier**
   Add cases to `approvalstore_test.go` using `t.TempDir()` for a fake `ConfigPath`: `RecordAlways` writes to `<path>/tool-approvals.yaml` with `0600` perms (BR14); a fresh `NewApprovalStore` pointed at that path loads the prior "always" approval (`IsApproved` returns true without a `RecordSession` call); different repo roots don't see each other's "always" approvals (FR7.1, the security-critical case flagged in NFR); a missing or malformed YAML file at construction yields zero approvals, not an error (BR15); `RecordAlways` is a safe no-op when `repoRoot == ""` (BR10's "not in a repo" case). Confirm compile failure.
 
-- [ ] **Step 6 - Implement `ApprovalStore` persisted tier**
+- [x] **Step 6 - Implement `ApprovalStore` persisted tier**
   Add YAML load/save (`gopkg.in/yaml.v3`, already a dependency per `cmd/config.go`), `RecordAlways`, the repo-root-keyed structure from `business-logic-model.md`. Run Step 5 tests, confirm green.
 
-- [ ] **Step 7 - Failing tests: `utils.FindGitBoundary`**
+- [x] **Step 7 - Failing tests: `utils.FindGitBoundary`**
   Add `TestFindGitBoundary` to `utils/utils_test.go`, porting the exact scenarios `cmd/projectcontext_test.go`'s existing boundary-related subtests already cover (match at cwd's own `.git`, match at a nested-parent's `.git`, no `.git` anywhere returns `""`, capped walk) so the extracted function is proven equivalent before the extraction happens. Confirm compile failure (function doesn't exist yet in `utils`).
 
-- [ ] **Step 8 - Extract `utils.FindGitBoundary`, refactor `cmd/projectcontext.go`**
+- [x] **Step 8 - Extract `utils.FindGitBoundary`, refactor `cmd/projectcontext.go`**
   Add `FindGitBoundary(dir string) string` to `utils/utils.go` (identical body to `cmd/projectcontext.go`'s current private `findGitBoundary`, including the 64-level cap). Delete the private copy in `cmd/projectcontext.go` and replace its one call site with `utils.FindGitBoundary(...)`. Run Step 7's new tests plus the full existing `cmd/projectcontext_test.go` suite unmodified, confirm all green (this proves the extraction preserved behavior exactly - #88's existing tests are the regression net).
 
-- [ ] **Step 9 - Failing tests: `Registry.Dispatch` gate-consulting behavior**
+- [x] **Step 9 - Failing tests: `Registry.Dispatch` gate-consulting behavior**
   Add cases to `tools/registry_test.go` using fake `Tool`/`PermissionGate` implementations: a non-destructive tool's `Execute` is called without ever touching the gate (BR5); a destructive tool with a `ConfirmationSummary` error returns an error `ToolResultBlock` without calling the gate or `Execute` (BR3-BR4); a gate returning `DecisionDeny` returns a declined-error `ToolResultBlock` without calling `Execute` (BR11); a gate returning any Allow variant calls `Execute` and returns its result. Confirm compile failure (signature doesn't match yet).
 
-- [ ] **Step 10 - Implement `Registry.Dispatch`'s extended signature**
+- [x] **Step 10 - Implement `Registry.Dispatch`'s extended signature**
   Change `Dispatch(ctx, call, gate PermissionGate) types.ToolResultBlock`, insert the gate-consulting logic from `business-logic-model.md`'s data-flow section. Run Step 9 tests, confirm green.
 
-- [ ] **Step 11 - Failing tests: `InteractivePermissionGate` prompt parsing**
+- [x] **Step 11 - Failing tests: `InteractivePermissionGate` prompt parsing**
   Create `cmd/permissionprompt_test.go` with cases using injected `strings.Reader`/`bytes.Buffer` (per Application Design's testability decision): each of `o`/`s`/`a`/`n` (case-insensitive) parses to the right `Decision`; empty input/EOF/unrecognized input defaults to deny (BR12); a session choice calls `store.RecordSession`; an always choice calls `store.RecordAlways` only when a repo root is available, and "always" isn't even offered in the prompt text when it isn't (BR10). Confirm compile failure.
 
-- [ ] **Step 12 - Implement `InteractivePermissionGate`**
+- [x] **Step 12 - Implement `InteractivePermissionGate`**
   Create `cmd/permissionprompt.go` per `domain-entities.md`'s shape. Run Step 11 tests, confirm green.
 
-- [ ] **Step 13 - Thread the gate through `runChatTurnWithTools` and its call sites**
+- [x] **Step 13 - Thread the gate through `runChatTurnWithTools` and its call sites**
   Add a `gate tools.PermissionGate` parameter to `runChatTurnWithTools` (`cmd/toolloop.go`), pass it through to the `registry.Dispatch(ctx, call, gate)` call. Update `cmd/chat.go`'s registry-construction block: build an `ApprovalStore` (via `os.Getwd()` + `utils.FindGitBoundary` + `fm.ConfigPath`) and an `InteractivePermissionGate` (`os.Stdin`/`os.Stdout`) alongside the existing `registry := tools.NewRegistry()` line, pass `gate` into both `runChatTurnWithTools` call sites. Update `cmd/toolturn_test.go`'s 2 call sites with a no-op fake gate (mirroring how `onReasoning` no-op callbacks were added in Initiative 1 Unit 5).
 
-- [ ] **Step 14 - Full verification**
+- [x] **Step 14 - Full verification**
   `make test`, `make lint`, `make test-coverage` (confirm no regression in `tools`/`cmd`/`utils`), `make cli && go test -tags=integration -v .`. No behavior change expected yet from a user's perspective (`read_file` is still the only registered tool, still non-destructive, still `--tools`-gated) - this step confirms the plumbing is correct and inert, ready for Unit 7 to actually exercise it.

--- a/aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md
@@ -8,32 +8,32 @@
 
 ## Steps
 
-- [ ] **Step 1 - Failing tests: `utils.ValidateLocalPathForWrite`**
+- [x] **Step 1 - Failing tests: `utils.ValidateLocalPathForWrite`**
   Add cases to `utils/utils_test.go`: a path to a file that doesn't exist yet succeeds (unlike `ValidateLocalPath`); a path traversal attempt (`../../etc/passwd`) is still rejected; re-run the full existing `TestValidateLocalPath` suite unmodified as a regression check that the refactor didn't change `ValidateLocalPath`'s behavior. Confirm compile failure.
 
-- [ ] **Step 2 - Implement `confineToWorkingDir` + `ValidateLocalPathForWrite`**
+- [x] **Step 2 - Implement `confineToWorkingDir` + `ValidateLocalPathForWrite`**
   Extract the confinement logic from `ValidateLocalPath` into a private `confineToWorkingDir(filename string) (string, error)`; refactor `ValidateLocalPath` to call it plus its existing existence check; add `ValidateLocalPathForWrite` calling only the confinement step. Run Step 1 tests plus full `utils` package, confirm all green.
 
-- [ ] **Step 3 - Failing tests: `WriteFileTool`**
+- [x] **Step 3 - Failing tests: `WriteFileTool`**
   Create `tools/writefile_test.go`: `RequiresConfirmation() == true`; `ConfirmationSummary` returns the expected summary text and a directory-based pattern key (BR5) for both an in-repo and a no-repo cwd; content over 4KB is truncated in the summary with the BR4 note; `Execute` creates a new file; `Execute` overwrites an existing file; `Execute` rejects a path outside the working directory. Confirm compile failure.
 
-- [ ] **Step 4 - Implement `WriteFileTool`**
+- [x] **Step 4 - Implement `WriteFileTool`**
   Create `tools/writefile.go` per `domain-entities.md`. Run Step 3 tests, confirm green.
 
-- [ ] **Step 5 - Failing tests: `RunShellTool`**
+- [x] **Step 5 - Failing tests: `RunShellTool`**
   Create `tools/runshell_test.go`: `RequiresConfirmation() == true`; `ConfirmationSummary` returns `"Run: <command>"` and the first-token pattern key (BR11), including the empty-command edge case; `Execute` returns command output on success; `Execute` embeds `[exit code: N]` for a non-zero exit **without** returning a Go error (BR10); `Execute` returns a Go error on timeout (using the injectable short timeout field, not the real 30s default); output over 32KB is truncated with the BR9 marker. Confirm compile failure.
 
-- [ ] **Step 6 - Implement `RunShellTool`**
+- [x] **Step 6 - Implement `RunShellTool`**
   Create `tools/runshell.go` per `domain-entities.md`, with `timeout time.Duration` as an unexported field (default 30s via `NewRunShellTool`). Run Step 5 tests, confirm green.
 
-- [ ] **Step 7 - Failing tests: `GitDiffTool`**
+- [x] **Step 7 - Failing tests: `GitDiffTool`**
   Create `tools/gitdiff_test.go`: `RequiresConfirmation() == false`; `Execute` with no `arg` runs a plain `git diff` in a temp git repo fixture; `Execute` with an `arg` passes it through; `Execute` outside a git repository returns an error containing git's own message (BR14). Confirm compile failure.
 
-- [ ] **Step 8 - Implement `GitDiffTool`**
+- [x] **Step 8 - Implement `GitDiffTool`**
   Create `tools/gitdiff.go` per `domain-entities.md`. Run Step 7 tests, confirm green.
 
-- [ ] **Step 9 - Register the 3 new tools in `cmd/chat.go`**
+- [x] **Step 9 - Register the 3 new tools in `cmd/chat.go`**
   Add `registry.Register(tools.NewWriteFileTool())`, `registry.Register(tools.NewRunShellTool())`, `registry.Register(tools.NewGitDiffTool())` alongside the existing `read_file` registration, still inside the `if toolsEnabled` block (Unit 8 removes that gate, not this unit). No new unit test needed beyond re-running the full `cmd` suite (registration is a one-line wiring change, same category as Initiative 1's established precedent for untested `chat.go` wiring).
 
-- [ ] **Step 10 - Full verification**
+- [x] **Step 10 - Full verification**
   `make test`, `make lint`, `make test-coverage` (confirm no regression), `make cli && go test -tags=integration -v .`. Manual smoke test against the compiled binary with `--tools` set: trigger `write_file` and confirm the prompt shows path+content and the once/session/always/deny choices work as expected; trigger `run_shell` similarly; trigger `git_diff` and confirm it runs with **no** prompt (read-only). This is the first point in the initiative where the confirmation gate actually fires - Unit 6 alone couldn't demonstrate this end-to-end.

--- a/aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/unit-7-new-tools-code-generation-plan.md
@@ -1,0 +1,39 @@
+# Code Generation Plan: Unit 7, New Built-in Tools (#86)
+
+## Unit Context
+- **Stories**: 7.1-7.3 (FR2.1-FR2.3, FR3.1-FR3.2, FR4.1-FR4.3)
+- **Design source**: `aidlc-docs/construction/unit-7-new-tools/functional-design/`, `.../nfr-requirements/nfr-requirements-and-design.md`
+- **Dependencies**: Unit 6 (HARD - `RequiresConfirmation`/`ConfirmationSummary`/`PermissionGate` must exist, which they do, per Unit 6's approved and merged code)
+- **Testability note**: `RunShellTool`'s 30s timeout would make a real timeout test slow. Since tests live in the same `tools` package, `RunShellTool`'s timeout is an unexported struct field constructible directly in tests (`&RunShellTool{timeout: 50 * time.Millisecond}`), not a hardcoded constant baked into `Execute`.
+
+## Steps
+
+- [ ] **Step 1 - Failing tests: `utils.ValidateLocalPathForWrite`**
+  Add cases to `utils/utils_test.go`: a path to a file that doesn't exist yet succeeds (unlike `ValidateLocalPath`); a path traversal attempt (`../../etc/passwd`) is still rejected; re-run the full existing `TestValidateLocalPath` suite unmodified as a regression check that the refactor didn't change `ValidateLocalPath`'s behavior. Confirm compile failure.
+
+- [ ] **Step 2 - Implement `confineToWorkingDir` + `ValidateLocalPathForWrite`**
+  Extract the confinement logic from `ValidateLocalPath` into a private `confineToWorkingDir(filename string) (string, error)`; refactor `ValidateLocalPath` to call it plus its existing existence check; add `ValidateLocalPathForWrite` calling only the confinement step. Run Step 1 tests plus full `utils` package, confirm all green.
+
+- [ ] **Step 3 - Failing tests: `WriteFileTool`**
+  Create `tools/writefile_test.go`: `RequiresConfirmation() == true`; `ConfirmationSummary` returns the expected summary text and a directory-based pattern key (BR5) for both an in-repo and a no-repo cwd; content over 4KB is truncated in the summary with the BR4 note; `Execute` creates a new file; `Execute` overwrites an existing file; `Execute` rejects a path outside the working directory. Confirm compile failure.
+
+- [ ] **Step 4 - Implement `WriteFileTool`**
+  Create `tools/writefile.go` per `domain-entities.md`. Run Step 3 tests, confirm green.
+
+- [ ] **Step 5 - Failing tests: `RunShellTool`**
+  Create `tools/runshell_test.go`: `RequiresConfirmation() == true`; `ConfirmationSummary` returns `"Run: <command>"` and the first-token pattern key (BR11), including the empty-command edge case; `Execute` returns command output on success; `Execute` embeds `[exit code: N]` for a non-zero exit **without** returning a Go error (BR10); `Execute` returns a Go error on timeout (using the injectable short timeout field, not the real 30s default); output over 32KB is truncated with the BR9 marker. Confirm compile failure.
+
+- [ ] **Step 6 - Implement `RunShellTool`**
+  Create `tools/runshell.go` per `domain-entities.md`, with `timeout time.Duration` as an unexported field (default 30s via `NewRunShellTool`). Run Step 5 tests, confirm green.
+
+- [ ] **Step 7 - Failing tests: `GitDiffTool`**
+  Create `tools/gitdiff_test.go`: `RequiresConfirmation() == false`; `Execute` with no `arg` runs a plain `git diff` in a temp git repo fixture; `Execute` with an `arg` passes it through; `Execute` outside a git repository returns an error containing git's own message (BR14). Confirm compile failure.
+
+- [ ] **Step 8 - Implement `GitDiffTool`**
+  Create `tools/gitdiff.go` per `domain-entities.md`. Run Step 7 tests, confirm green.
+
+- [ ] **Step 9 - Register the 3 new tools in `cmd/chat.go`**
+  Add `registry.Register(tools.NewWriteFileTool())`, `registry.Register(tools.NewRunShellTool())`, `registry.Register(tools.NewGitDiffTool())` alongside the existing `read_file` registration, still inside the `if toolsEnabled` block (Unit 8 removes that gate, not this unit). No new unit test needed beyond re-running the full `cmd` suite (registration is a one-line wiring change, same category as Initiative 1's established precedent for untested `chat.go` wiring).
+
+- [ ] **Step 10 - Full verification**
+  `make test`, `make lint`, `make test-coverage` (confirm no regression), `make cli && go test -tags=integration -v .`. Manual smoke test against the compiled binary with `--tools` set: trigger `write_file` and confirm the prompt shows path+content and the once/session/always/deny choices work as expected; trigger `run_shell` similarly; trigger `git_diff` and confirm it runs with **no** prompt (read-only). This is the first point in the initiative where the confirmation gate actually fires - Unit 6 alone couldn't demonstrate this end-to-end.

--- a/aidlc-docs/construction/plans/unit-8-automatic-enablement-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/unit-8-automatic-enablement-code-generation-plan.md
@@ -1,0 +1,24 @@
+# Code Generation Plan: Unit 8, Automatic Tool-Use Enablement (#86) - Final Unit
+
+## Unit Context
+- **Stories**: 6.1-6.2 (FR1.1-FR1.4)
+- **Design source**: `aidlc-docs/construction/unit-8-automatic-enablement/functional-design/business-logic-model.md`, `.../nfr-requirements/nfr-requirements-and-design.md`
+- **Dependencies**: Units 6+7 (soft - registry now has the full 4-tool set and working gate to attach unconditionally)
+- **Testing precedent** (verified, not assumed): `cmd/inferenceconfig_test.go` unit-tests `isDeprecatedSamplingParamsError` directly (pure function) but never `converseStreamWithFallbacks`/`converseWithFallbacks` themselves - they call the real, unmockable `*bedrockruntime.Client`. This unit follows the exact same pattern: `isToolUseUnsupportedError` gets direct unit tests; the new retry branch inside `converseStreamWithFallbacks` is verified via the full suite + manual check, not a new mocked-client test.
+
+## Steps
+
+- [x] **Step 1 - Failing tests: `isToolUseUnsupportedError`**
+  Add `TestIsToolUseUnsupportedError` to `cmd/inferenceconfig_test.go`, mirroring `TestIsDeprecatedSamplingParamsError`'s table-driven style: nil error → false; unrelated error → false; a message containing "tool" + "not supported" → true; "tool" + "does not support" → true; "tool" + "unsupported" → true; a message containing "tool" but no matching qualifier → false; a message with a qualifier but no "tool" (e.g. a caching-rejection message) → false. Confirm compile failure.
+
+- [x] **Step 2 - Implement `isToolUseUnsupportedError`**
+  Add to `cmd/inferenceconfig.go` per `business-logic-model.md`. Run Step 1 tests, confirm green.
+
+- [x] **Step 3 - Add the tool-use retry stage to `converseStreamWithFallbacks`**
+  Insert the `input.ToolConfig != nil && isToolUseUnsupportedError(err)` branch between the existing cache-point and deprecated-sampling-params stages, per `business-logic-model.md`. No new unit test for this branch itself (see Unit Context's testing-precedent note) - verified via Step 5's full suite and manual check.
+
+- [x] **Step 4 - Remove `--tools`**
+  Delete the `rootCmd.PersistentFlags().Bool("tools", false, ...)` registration in `cmd/root.go`. Delete the `toolsEnabled` flag-read and the `if toolsEnabled { ... }` gate in `cmd/chat.go` - tool registration (all 4 tools, plus the gate construction already unconditional since Unit 6) becomes fully unconditional. Update `TestCLIFlagsExist` in `integration_test.go` if `--tools` is asserted there (check first - Initiative 2's flags were the ones added to that test, `--tools` predates it).
+
+- [x] **Step 5 - Full verification**
+  `make test`, `make lint`, `make test-coverage` (confirm no regression), `make cli && go test -tags=integration -v .`. Manual verification (same real-components approach as Unit 7, since live Bedrock isn't reachable here): confirm `chat-cli --help` no longer lists `--tools`; confirm a `chat` session's registry always contains all 4 tools regardless of any flag (inspect via a quick scratch driver, not the full TUI); this is the last unit of Initiative 3 - once green, proceed to the initiative-wide Build and Test stage covering all 3 units together.

--- a/aidlc-docs/construction/unit-6-confirmation-engine/code/summary.md
+++ b/aidlc-docs/construction/unit-6-confirmation-engine/code/summary.md
@@ -1,0 +1,32 @@
+# Code Generation Summary: Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+## Files Created
+- `tools/permission.go` - `Decision` type/constants, `PermissionGate` interface
+- `tools/approvalstore.go` - `ApprovalStore` (session tier in-memory, always tier persisted YAML at `<ConfigPath>/tool-approvals.yaml`, `0600`, keyed by repo root), `CanRecordAlways`
+- `tools/approvalstore_test.go` - 3 session-tier subtests, 5 always-tier subtests
+- `cmd/permissionprompt.go` - `InteractivePermissionGate`, the concrete terminal-facing gate
+- `cmd/permissionprompt_test.go` - choice parsing (11 subtests), session/always recording, not-offered-outside-a-repo, prior-approval-skips-the-prompt
+
+## Files Modified
+- `tools/tool.go` - `Tool` interface gains `RequiresConfirmation()`/`ConfirmationSummary()`
+- `tools/readfile.go` - implements the 2 new methods (`RequiresConfirmation() == false`)
+- `tools/registry.go` - `Dispatch` signature gains a `gate PermissionGate` parameter; gate-consulting logic inserted before `Execute`
+- `tools/registry_test.go` - `fakeTool` updated for the extended interface; new `fakeDestructiveTool`/`fakeGate` test doubles; 4 new `Dispatch` gate-consulting test cases; 3 existing calls updated to pass `nil` (safe - none of their fakes require confirmation)
+- `utils/utils.go` - new exported `FindGitBoundary` (extracted from `cmd/projectcontext.go`'s private `findGitBoundary`)
+- `utils/utils_test.go` - new `TestFindGitBoundary`
+- `cmd/projectcontext.go` - private `findGitBoundary` deleted, call site now uses `utils.FindGitBoundary`
+- `cmd/toolloop.go` - `runChatTurnWithTools` gains a `gate tools.PermissionGate` parameter, threaded to `registry.Dispatch`
+- `cmd/toolturn_test.go` - `fakeTurnTool` updated for the extended interface; 2 call sites pass `nil` (safe - non-destructive fake)
+- `cmd/chat.go` - constructs a real `ApprovalStore`/`InteractivePermissionGate` alongside the existing registry-construction block; both `runChatTurnWithTools` call sites pass it through
+
+## Design Deviations from Functional Design (minor, during implementation)
+- **Persisted-entry format corrected during implementation**: the first draft accidentally used the internal NUL-joined key (`"toolName\x00patternKey"`) for on-disk storage. Caught and fixed before tests were written against it - the persisted format uses the documented human-readable `"toolName:patternKey"` (`business-logic-model.md`), parsed back with `strings.Cut` on load. The in-memory maps still use the NUL-joined key internally.
+- **`ApprovalStore.CanRecordAlways() bool`** - a small addition not explicitly listed in `component-methods.md`, needed so `InteractivePermissionGate` can decide whether to offer/accept "always" as a choice (BR10) without reaching into the store's private `repoRoot` field.
+- **Go's whole-package compilation forced Steps 11-13 together**: writing `cmd/permissionprompt_test.go` (Step 11) couldn't compile in isolation once `Registry.Dispatch`'s signature changed (Step 10), since `cmd/toolloop.go`'s existing call site broke immediately. Steps 12 (implement the gate) and 13 (thread it through `chat.go`/`toolloop.go`/`toolturn_test.go`) were completed together with Step 11 rather than strictly sequentially - the TDD red/green discipline was preserved per-function, just not per-step-boundary.
+
+## Test Results
+- `make test`: all packages pass, no regressions (2 pre-existing `SKIP`s unrelated to this unit)
+- `make lint`: clean
+- Coverage: `cmd` 31.8% → 33.3%, `tools` 90.0% → 84.1% (new untested edge branches in `approvalstore.go`'s malformed-file-merge path; still high), `utils` 51.8% → 53.7%, total 67.8% → 69.7% - no regression
+- `go test -tags=integration -v .`: 7/7 pass
+- No user-visible behavior change from this unit alone (by design) - `read_file` remains the only registered tool and is non-destructive, so the new gate is fully wired but never actually triggered yet. Unit 7 will be the first unit to exercise it end-to-end.

--- a/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/business-logic-model.md
+++ b/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/business-logic-model.md
@@ -1,0 +1,82 @@
+# Functional Design: Business Logic Model - Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+## Context
+Verified against the actual current codebase rather than assumed:
+- `tools/tool.go`/`tools/registry.go` (Initiative 1 Unit 2, reviewed in Application Design) - the interface/`Dispatch` extension points this unit builds on.
+- `utils/utils.go`'s `StringPrompt` - **deliberately not reused**. It launches a full `bubbletea` text-input widget for free-form entry (chat messages), which is the wrong shape for a discrete once/session/always/deny choice and harder to unit-test (a full TUI program lifecycle vs. a plain `io.Reader`). This unit implements its own minimal prompt instead.
+- `config.FileManager.ConfigPath` (exported, `config/config.go:16`) - reused as the base directory for the new persisted approvals file, consistent with where chat-cli already keeps its config/DB.
+
+## Core Components (from Application Design, detailed here)
+
+### 1. Extended `tools.Tool` Interface
+```go
+RequiresConfirmation() bool
+ConfirmationSummary(input json.RawMessage) (summary string, patternKey string, err error)
+```
+- `ConfirmationSummary` is called with the **same raw input** `Execute` will receive - it must parse it itself (duplicating the unmarshal `Execute` also does). This is accepted duplication, not a design flaw: keeping the two methods independent means a summary-generation bug can never accidentally skip validation that `Execute` would have caught, and vice versa - each method is a complete, independently-testable unit.
+- If `ConfirmationSummary` itself fails to parse the input (malformed JSON from the model), that's treated as a **denial-equivalent**: `Registry.Dispatch` returns an error `ToolResultBlock` immediately, without ever calling the gate or `Execute` - a call that can't even be summarized can't be meaningfully confirmed.
+
+### 2. `PermissionGate` / `Decision`
+```go
+type Decision int
+const (
+    DecisionAllowOnce Decision = iota
+    DecisionAllowSession
+    DecisionAllowAlways
+    DecisionDeny
+)
+type PermissionGate interface {
+    Check(toolName, patternKey, summary string) Decision
+}
+```
+
+### 3. `ApprovalStore` - Two Tiers
+- **Session tier**: `map[string]bool` keyed by `toolName + "\x00" + patternKey` (a byte unlikely to appear in either, avoiding a delimiter-collision edge case that a simple `":"` join could hit if a pattern key ever contained a colon). Lives only in memory, created fresh per `chat` process, discarded on exit.
+- **Always tier**: persisted at `<fm.ConfigPath>/tool-approvals.yaml`, structure:
+  ```yaml
+  repos:
+    /absolute/path/to/repo-root:
+      - "run_shell:git"
+      - "write_file:src"
+  ```
+  Keyed by the **absolute** repo-root path (from `utils.FindGitBoundary`) at the top level - this is the per-repository scoping FR7.1 requires. Within a repo's list, entries are `"toolName:patternKey"` strings (simpler to serialize/diff than nested YAML, and human-readable/editable if someone wants to hand-edit the file).
+  - File permissions: `0600` (owner read/write only) on creation, matching NFR1.
+  - Loaded once at `ApprovalStore` construction (one read), only written to on a `RecordAlways` call - `IsApproved` never touches disk.
+  - A repo root that isn't yet a key in the file, or a missing file entirely, is treated as "no always-approvals for this repo" - never an error.
+
+### 4. Pattern Key Derivation (business rules detailed in `business-rules.md`)
+- `run_shell`: base command = the first whitespace-separated token of the command string.
+- `write_file`: containing directory, **relative to the repo root** (not absolute) - keeps the persisted file portable if the repo is later cloned to a different absolute path, and keeps entries human-readable.
+
+### 5. `InteractivePermissionGate`
+```go
+type InteractivePermissionGate struct {
+    store  *tools.ApprovalStore
+    reader io.Reader // defaults to os.Stdin in production
+    writer io.Writer // defaults to os.Stdout in production
+}
+```
+- Constructor takes the reader/writer explicitly (not defaulted internally) so Code Generation's tests can inject a `strings.Reader`/`bytes.Buffer` and exercise the full prompt-parsing logic without a real terminal - resolves the "testability of the interactive prompt" question Application Design deferred.
+- `Check` flow: look up `store.IsApproved(toolName, patternKey)` first (covers both tiers - `ApprovalStore` itself checks session then always internally) → if approved, return `DecisionAllowOnce`-equivalent (no prompt) → else print the summary + choice prompt to `writer`, read one line from `reader`, parse the first non-whitespace character case-insensitively (`o`/`s`/`a`/`n`, default to deny on empty/EOF/unrecognized input - a fail-closed default per NFR1) → on session/always, call the matching `store.Record*` method → return the decision.
+
+## Data Flow
+
+```
+Registry.Dispatch(call, gate)
+  -> tool := lookup(call.Name)
+  -> if !tool.RequiresConfirmation(): Execute directly
+  -> else:
+       summary, patternKey, err := tool.ConfirmationSummary(call.Input)
+       if err != nil: return error ToolResultBlock (never reaches the gate)
+       decision := gate.Check(tool.Name(), patternKey, summary)
+       if decision == Deny: return declined-error ToolResultBlock
+       else: Execute(call.Input)  // Once/Session/Always all mean "proceed now"
+
+gate.Check(toolName, patternKey, summary):
+  -> if store.IsApproved(toolName, patternKey): return AllowOnce (skip prompt)
+  -> print summary + prompt to writer
+  -> read one line from reader, parse choice
+  -> on Session: store.RecordSession(...)
+  -> on Always: store.RecordAlways(...) (writes to disk)
+  -> return the parsed Decision
+```

--- a/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/business-rules.md
+++ b/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/business-rules.md
@@ -1,0 +1,26 @@
+# Functional Design: Business Rules - Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+## Pattern Key Derivation
+- **BR1**: `run_shell`'s pattern key is the command string's first whitespace-separated token (e.g. `"git diff main"` → `"git"`). Leading/trailing whitespace is trimmed before splitting. An empty command string (shouldn't happen given the tool's own input validation, but defensively) yields an empty pattern key, which never matches any prior approval and always prompts.
+- **BR2**: `write_file`'s pattern key is the containing directory of the resolved (validated) path, **relative to the repo root** determined by `utils.FindGitBoundary`. A file directly at the repo root has pattern key `"."`. If `chat` isn't running inside a git repository at all (`FindGitBoundary` returns `""`), the pattern key falls back to the directory relative to the current working directory instead - "always" approval in that case is scoped to `ApprovalStore`'s in-memory-only behavior (see BR9), since there's no meaningful repo root to key persistence off of.
+
+## Confirmation Gate Sequencing
+- **BR3**: `ConfirmationSummary` is called (and can fail-closed, per BR4) **before** the gate is ever consulted - a call whose input can't be summarized never reaches the user or the approval-lookup logic.
+- **BR4**: A `ConfirmationSummary` parse error is treated identically to a denial: an error `ToolResultBlock` is returned to the model immediately, no prompt shown, no store lookup performed, `Execute` never called.
+- **BR5**: `git_diff`/`read_file` (`RequiresConfirmation() == false`) never call `ConfirmationSummary` at all - `Dispatch` calls `Execute` directly, exactly as it does today for `read_file`.
+
+## Approval Lookup and Recording
+- **BR6**: Before showing a prompt, `gate.Check` always checks `store.IsApproved(toolName, patternKey)` first. A match (from either tier) skips the prompt entirely and proceeds as if the user had just chosen "once" for this specific call.
+- **BR7**: `store.IsApproved` checks the **session tier first, then the always tier** - functionally equivalent either order (both are simple "does an approval exist" checks), but session-first avoids an unnecessary disk-backed lookup path in the common case of a within-session repeat.
+- **BR8**: Choosing "once" never calls any `Record*` method - by definition, it doesn't persist, in either tier.
+- **BR9**: Choosing "session" calls `RecordSession` (in-memory only, never touches disk) - covers both the "inside a repo" and "not inside a repo" cases identically, since the session tier was never repo-scoped to begin with (only the always tier needs `FindGitBoundary`).
+- **BR10**: Choosing "always" calls `RecordAlways`, which writes to `<fm.ConfigPath>/tool-approvals.yaml`. If `FindGitBoundary` returned `""` (not inside a git repo), "always" is **not offered** as a choice at the prompt (only once/session/deny) - there's no repo root to scope it to, and scoping an "always" approval to an arbitrary non-repo cwd would be a much easier approval to accidentally over-apply.
+- **BR11**: A denied call (`DecisionDeny`) never calls any `Record*` method - a denial is never sticky (Story 8.3), the user is prompted again next time regardless of tier.
+
+## Prompt Input Parsing
+- **BR12**: The prompt reads exactly one line from the injected reader. The first non-whitespace character, lowercased, is matched: `o` → once, `s` → session, `a` → always (only offered per BR10), `n` → deny. Any other input (empty line, EOF, unrecognized character) defaults to **deny** - a fail-closed default, never fail-open.
+- **BR13**: The prompt is shown exactly once per `Check` call that isn't short-circuited by BR6 - there is no retry-on-invalid-input loop in this pass (an invalid entry is simply a denial for that call; the model can ask again, prompting the user again).
+
+## Storage Integrity
+- **BR14**: `tool-approvals.yaml` is created with `0600` permissions if it doesn't exist. An existing file with looser permissions is not forcibly re-chmod'd in this pass (out of scope - not a regression this unit introduces, since the file doesn't exist before this unit ships).
+- **BR15**: A malformed or unreadable `tool-approvals.yaml` at `ApprovalStore` construction is treated as "no persisted approvals" (empty always-tier) rather than a fatal error - consistent with #88's precedent of degrading gracefully on file-read problems (NFR4-equivalent reliability rule).

--- a/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/domain-entities.md
+++ b/aidlc-docs/construction/unit-6-confirmation-engine/functional-design/domain-entities.md
@@ -1,0 +1,68 @@
+# Functional Design: Domain Entities - Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+## `tools/tool.go` (modified)
+Adds to the existing `Tool` interface:
+```go
+RequiresConfirmation() bool
+ConfirmationSummary(input json.RawMessage) (summary string, patternKey string, err error)
+```
+
+## `tools/permission.go` (new)
+```go
+type Decision int
+const (
+    DecisionAllowOnce Decision = iota
+    DecisionAllowSession
+    DecisionAllowAlways
+    DecisionDeny
+)
+
+type PermissionGate interface {
+    Check(toolName, patternKey, summary string) Decision
+}
+```
+
+## `tools/approvalstore.go` (new)
+```go
+type ApprovalStore struct {
+    repoRoot string             // "" if not inside a git repo (BR2)
+    session  map[string]bool    // in-memory, this-process-only
+    always   map[string][]string // loaded from disk, keyed by repo root
+    path     string             // <fm.ConfigPath>/tool-approvals.yaml
+}
+
+func NewApprovalStore(configPath, repoRoot string) (*ApprovalStore, error)
+func (s *ApprovalStore) IsApproved(toolName, patternKey string) bool
+func (s *ApprovalStore) RecordSession(toolName, patternKey string)
+func (s *ApprovalStore) RecordAlways(toolName, patternKey string) error // no-op-safe if repoRoot == ""
+```
+- `NewApprovalStore` loads the YAML file at construction (BR15: tolerant of missing/malformed file).
+- The `key(toolName, patternKey string) string` helper (internal) joins with `"\x00"` per the business-logic-model's delimiter-collision note.
+
+## `tools/registry.go` (modified)
+```go
+func (r *Registry) Dispatch(ctx context.Context, call ToolCall, gate PermissionGate) types.ToolResultBlock
+```
+- New logic inserted between the existing "look up tool" and "call Execute" steps (BR3-BR6).
+
+## `cmd/permissionprompt.go` (new)
+```go
+type InteractivePermissionGate struct {
+    store  *tools.ApprovalStore
+    reader io.Reader
+    writer io.Writer
+}
+
+func NewInteractivePermissionGate(store *tools.ApprovalStore, reader io.Reader, writer io.Writer) *InteractivePermissionGate
+func (g *InteractivePermissionGate) Check(toolName, patternKey, summary string) tools.Decision
+```
+- Production call site in `cmd/chat.go` constructs it with `os.Stdin`/`os.Stdout`; tests inject `strings.Reader`/`bytes.Buffer`.
+
+## `utils/utils.go` (modified - extraction)
+```go
+func FindGitBoundary(dir string) string
+```
+- Moved from `cmd/projectcontext.go`'s private `findGitBoundary` (identical body/behavior, 64-level cap and all) - `cmd/projectcontext.go` is refactored to call `utils.FindGitBoundary` instead of keeping its own copy.
+
+## New Persisted File (not Go code, but a new artifact this unit introduces)
+`<fm.ConfigPath>/tool-approvals.yaml` - see `business-logic-model.md`'s storage format. Created lazily on the first `RecordAlways` call; absent until then.

--- a/aidlc-docs/construction/unit-6-confirmation-engine/nfr-requirements/nfr-requirements-and-design.md
+++ b/aidlc-docs/construction/unit-6-confirmation-engine/nfr-requirements/nfr-requirements-and-design.md
@@ -1,0 +1,47 @@
+# NFR Requirements and Design (Combined): Unit 6, Confirmation and Sticky Approval Engine (#86)
+
+Combined presentation, same pattern as Initiative 1 Units 2/4 and Initiative 2 - Security is the dominant category here (this unit exists specifically to make destructive actions safe), with Reliability and Usability as secondary but real concerns given a broken gate is worse than no gate at all.
+
+## Security
+
+### Requirement
+The gate must be the actual, sole control for destructive actions - there must be no code path where `write_file`/`run_shell` execute without a decision having been recorded, and the persisted approval store must not be a soft target (unreadable by other users, not trivially spoofable).
+
+### Design
+- **`Registry.Dispatch` is the single choke point** - `write_file`/`run_shell`'s `Execute` methods are never called directly by anything else in the codebase (same principle as Unit 2's `ValidateLocalPath` choke point). A future tool that forgets to implement `RequiresConfirmation()` correctly is the only way to bypass this - mitigated by the interface requiring an explicit `bool` return (can't be silently omitted, Go interfaces are structurally checked at compile time).
+- **Fail-closed everywhere**: unparseable `ConfirmationSummary` input → denial (BR4); unrecognized/empty prompt input → denial (BR12); malformed persisted-store file → treated as *no* approvals, not as approve-everything (BR15). Every ambiguous state resolves to "ask again" or "deny," never to "allow."
+- **`tool-approvals.yaml` created with `0600`** (owner-only) - matches the existing config file's implicit trust model (chat-cli already stores AWS-adjacent config in the same directory tree with no additional access-control layer; this doesn't introduce a new class of secret, just a new class of "things this user has said yes to").
+- **Per-repository scoping is itself a security boundary**, not just a UX nicety (FR7.1) - an "always" approval for `git *` in a trusted personal project must not silently apply when the same user runs `chat-cli` inside a cloned, less-trusted repository. Verified explicitly in Story 8.2's acceptance criteria and will get a dedicated Build and Test scenario.
+- **No new attack surface from the persisted file's *content*** - it stores only `toolName:patternKey` strings the user themselves approved; it's not executable, not interpreted as anything beyond an approval-lookup key, and a corrupted file degrades to "no approvals" (BR15) rather than being parsed permissively.
+
+### Compliance
+✅ Compliant - single choke point, fail-closed on every ambiguous state, repo-scoped persistence, restrictive file permissions.
+
+## Reliability
+
+### Requirement
+A confirmation-engine bug must never crash `chat` outright, and must never silently skip the gate (a crash is preferable to a silent bypass, but "ask again" is preferable to either).
+
+### Design
+- BR15: a corrupted/missing `tool-approvals.yaml` degrades to empty approvals (re-prompt for everything) rather than a fatal error at `chat` startup - consistent with #88's established graceful-degradation precedent for file-read problems.
+- BR13: no retry-loop on invalid prompt input - a single bad keystroke just means "denied, try again next time the model asks" rather than the CLI hanging on a re-prompt loop or crashing on unexpected input.
+- The gate's `Check` call happens synchronously inside the existing tty-loop (no new goroutines, no new concurrency-related failure modes) - consistent with Application Design's stated communication pattern.
+
+### Compliance
+✅ Compliant - no fatal-error path introduced by this unit; every failure mode degrades to a safe, expected state (re-prompt or deny).
+
+## Usability
+
+### Requirement
+The confirmation prompt must give enough information for an informed decision without becoming an obstacle so heavy that users reflexively approve without reading (NFR5 from requirements.md).
+
+### Design
+- The prompt always shows the tool-specific summary (exact command string for `run_shell`; path + content for `write_file`) before asking for a decision - never a generic "allow this tool call?" with no specifics.
+- For `write_file`, content over a readable threshold (4KB) is shown truncated with an explicit "N bytes total, shown truncated" note, rather than either flooding the terminal with a huge write or hiding the size entirely - balances informed-decision-making against practical terminal usability (exact threshold documented as a Code Generation detail, not re-litigated here).
+- The three approval tiers are presented with their consequence stated plainly (e.g. "session" vs "always" - not just single letters with no explanation) at the prompt itself, so the choice's scope is clear in the moment, not just in documentation.
+
+### Compliance
+✅ Compliant - informative by default, with a stated (not silent) truncation policy for oversized content.
+
+## Non-Applicable Categories
+- **Scalability/Performance/Availability**: N/A - same rationale as every prior unit in this project (single local process, no concurrent-load concept). The gate's own overhead is one YAML file read at startup and (rarely) one write - negligible.

--- a/aidlc-docs/construction/unit-7-new-tools/code/summary.md
+++ b/aidlc-docs/construction/unit-7-new-tools/code/summary.md
@@ -1,0 +1,32 @@
+# Code Generation Summary: Unit 7, New Built-in Tools (#86)
+
+## Files Created
+- `tools/writefile.go` - `WriteFileTool` (destructive, cwd-confined via new `utils.ValidateLocalPathForWrite`)
+- `tools/writefile_test.go` - 10 subtests
+- `tools/runshell.go` - `RunShellTool` (destructive, 30s timeout with real process-group kill, 32KB truncated output, non-zero exit embedded in output text)
+- `tools/runshell_test.go` - 8 subtests
+- `tools/gitdiff.go` - `GitDiffTool` (read-only, no confirmation gate)
+- `tools/gitdiff_test.go` - 4 subtests
+
+## Files Modified
+- `utils/utils.go` - new `confineToWorkingDir` private helper shared by the unchanged `ValidateLocalPath` and the new `ValidateLocalPathForWrite`
+- `utils/utils_test.go` - new `TestValidateLocalPathForWrite`; existing `TestValidateLocalPath` re-run unmodified as a regression check
+- `cmd/chat.go` - registers `write_file`/`run_shell`/`git_diff` alongside `read_file` (still inside the `toolsEnabled` gate; Unit 8 removes that gate, not this unit)
+
+## Bug Found and Fixed During Implementation (not in the original functional design)
+**`RunShellTool`'s timeout didn't actually bound wall-clock time for commands with grandchild processes.** The initial implementation used `exec.CommandContext`, which only kills the direct child (`sh`) on timeout. A command like `sh -c "sleep 5"` makes `sleep` a *grandchild*, and `CombinedOutput()`'s internal pipe-reading blocks until every process holding the output pipe open exits - killing only `sh` left `sleep` running and the pipe open, so `Execute` didn't actually return until the full 5 seconds elapsed regardless of a 50ms timeout.
+
+Caught because the test asserted correctness (an error was returned) but the test run itself took the full 5 seconds instead of the expected ~50ms - a "passing but suspiciously slow" signal. Fixed by running the command in its own process group (`SysProcAttr{Setpgid: true}`) and killing the whole group (`syscall.Kill(-pid, SIGKILL)`) on timeout, racing the blocking `CombinedOutput()` call against `ctx.Done()` in a `select`. The test now asserts both correctness *and* that `Execute` returns within 2 seconds (not just eventually) so this class of regression can't silently return. Full suite dropped from 5.02s to 0.066s after the fix.
+
+## Manual Verification (real components, no AWS credentials needed)
+Since driving a live model into requesting a tool call isn't possible in this environment, verified the actual wiring by constructing the real `Registry`, real tools, and the real `InteractivePermissionGate`/`ApprovalStore` and calling `Dispatch` exactly as `chat.go` does, with scripted stdin:
+1. `write_file` + approve once → file created with correct content
+2. `write_file` + deny → file NOT created, model receives an error `ToolResultBlock`, no crash
+3. `run_shell` + approve "session" → first call prompts; a second call with the same base command (`echo`) skips the prompt entirely, confirming session-tier sticky approval works end-to-end
+4. `git_diff` with an empty/unreadable stdin → reached and errored immediately (not a git repo) without ever attempting to read from stdin, confirming the gate is never consulted for non-destructive tools
+
+## Test Results
+- `make test`: all packages pass, no regressions
+- `make lint`: clean
+- Coverage: `cmd` 33.3%→33.1% (negligible, no logic removed), `tools` 84.1%→81.9% (new untested edge branches, still high), `utils` 53.7%→55.0%, total 69.7%→71.2%
+- `go test -tags=integration -v .`: 7/7 pass

--- a/aidlc-docs/construction/unit-7-new-tools/functional-design/business-logic-model.md
+++ b/aidlc-docs/construction/unit-7-new-tools/functional-design/business-logic-model.md
@@ -1,0 +1,31 @@
+# Functional Design: Business Logic Model - Unit 7, New Built-in Tools (#86)
+
+## Context
+Verified against the actual current codebase, not assumed.
+
+## Important Finding: `utils.ValidateLocalPath` Requires the File to Already Exist
+
+`utils.ValidateLocalPath` (`utils/utils.go:74`) does two things: confines resolution to the working directory, **and** errors if the file doesn't exist (`os.Stat`/`os.IsNotExist`). This is correct for its existing callers (`read_file`, `--document`, `--image` - all read-only), but `write_file` must support *creating* a new file (FR2.2), which would always fail existence-checking.
+
+**Decision**: rather than changing `ValidateLocalPath`'s signature (which would ripple across Units 2/4's already-shipped call sites for no benefit to them), extract the shared confinement-only logic into a private helper both functions call, and add a new sibling function:
+
+```go
+func ValidateLocalPath(filename string) (string, error)         // unchanged contract - existence required
+func ValidateLocalPathForWrite(filename string) (string, error) // confinement only, no existence check
+```
+
+This is additive, not a refactor of existing behavior - `ValidateLocalPath`'s callers (Units 2/4) are unaffected, zero regression risk to already-shipped code. Contrast with Unit 6's `FindGitBoundary` extraction, which *did* change an existing private function's location - this is lower-risk since nothing existing is being moved or altered.
+
+## `WriteFileTool`
+- `RequiresConfirmation()` → `true`
+- `ConfirmationSummary`: unmarshals `{"path":"...","content":"..."}`, calls `utils.ValidateLocalPathForWrite`. On success, summary is `"Write to <path>:\n<content, or a truncated preview past 4KB per the NFR usability decision>"`. Pattern key (BR2, Unit 6's design): the containing directory of the resolved path, relative to the git repo root (`utils.FindGitBoundary(cwd)`) if inside one, else relative to cwd itself.
+- `Execute`: re-validates via `ValidateLocalPathForWrite` (never trusts the summary step's validation alone - each method is independently complete, per Unit 6's stated principle), writes the file (`os.WriteFile`, mode `0600` for new files; an existing file's mode is preserved by `os.WriteFile`'s overwrite behavior... **correction**: `os.WriteFile` always applies the given perm only when *creating* a new file - an existing file keeps its current mode regardless of the perm argument, which is exactly the desired behavior here with no extra code needed).
+
+## `RunShellTool`
+- `RequiresConfirmation()` → `true`
+- `ConfirmationSummary`: unmarshals `{"command":"..."}`, summary is `"Run: <command>"`, pattern key is the command's first whitespace-separated token (`strings.Fields(command)[0]`, or `""` if the command is empty/whitespace-only - never matches a prior approval, always prompts).
+- `Execute`: `exec.CommandContext` with a 30s timeout (`context.WithTimeout`), `Dir` set to `os.Getwd()`'s result, `sh -c "<command>"`, combined stdout+stderr via `CombinedOutput()`, truncated at 32KB (mirrors #88's precedent constant). A **non-zero exit code is not a Go error** - it's embedded in the returned text (`"[exit code: N]\n<output>"`) so the model sees the command ran and can react to its failure, the same way a human running the command would see both the output and the exit status. A **timeout** (`ctx.Err() == context.DeadlineExceeded`) or a failure to start the shell at all *are* returned as Go errors (distinct failure classes from "the command the model asked for ran and failed").
+
+## `GitDiffTool`
+- `RequiresConfirmation()` → `false` (read-only)
+- `Execute`: unmarshals `{"arg":"..."}` (optional, may be absent/empty), runs `git diff [arg]` via `exec.CommandContext` (same 30s timeout for consistency, though git diff is expected to be fast) in `os.Getwd()`. No `FindGitBoundary` involvement needed - `git diff` itself already reports "not a git repository" (or an invalid-ref error) via a non-zero exit and stderr text if run outside a repo or with a bad argument; that stderr text becomes the tool's returned error, giving the model the same clear signal git itself would give a human.

--- a/aidlc-docs/construction/unit-7-new-tools/functional-design/business-rules.md
+++ b/aidlc-docs/construction/unit-7-new-tools/functional-design/business-rules.md
@@ -1,0 +1,25 @@
+# Functional Design: Business Rules - Unit 7, New Built-in Tools (#86)
+
+## `write_file`
+- **BR1**: Path confinement uses `utils.ValidateLocalPathForWrite` (new, confinement-only) - identical traversal protection to `read_file`/`--document`/`--image`, minus the existence requirement.
+- **BR2**: Both creating a new file and overwriting an existing one are in scope (FR2.2) - no separate "create" vs "overwrite" tool or flag.
+- **BR3**: `ConfirmationSummary` and `Execute` each independently call `ValidateLocalPathForWrite` - neither trusts the other's validation, consistent with Unit 6's stated design principle (business-logic-model.md: "keeping the two methods independent means a summary-generation bug can never accidentally skip validation Execute would have caught").
+- **BR4**: The confirmation summary shows full content up to 4KB; past that, a truncated preview plus an explicit `"(N bytes total, shown truncated)"` note (NFR5/Unit 6 NFR's usability decision, carried forward).
+- **BR5**: Pattern key is the resolved path's containing directory, relative to the git repo root if inside one (`utils.FindGitBoundary`), else relative to cwd (Unit 6 BR2).
+
+## `run_shell`
+- **BR6**: Runs via `sh -c "<command>"`, no allowlist/denylist (Requirements Analysis Assumption 2) - the confirmation gate (Unit 6) is the control.
+- **BR7**: Working directory is fixed to `chat-cli`'s own cwd (`os.Getwd()`), not configurable by the model.
+- **BR8**: A 30-second timeout applies to every invocation. Exceeding it returns a Go error (`"command timed out after 30s"`), distinct from a normal non-zero exit.
+- **BR9**: Combined stdout+stderr is truncated at 32KB with a `"(output truncated)"` marker appended, mirroring #88's `maxContextFileSize` precedent for consistency across the codebase.
+- **BR10**: A non-zero exit code is **not** a Go error - it's reported in the tool's success-path output text as `"[exit code: N]"` followed by the (possibly truncated) combined output, so the model can see both the failure and why.
+- **BR11**: Pattern key is the command's first whitespace-separated token; an empty/whitespace-only command yields an empty pattern key (never matches, always prompts - same fail-safe shape as Unit 6 BR1's `run_shell` note).
+
+## `git_diff`
+- **BR12**: No confirmation gate - read-only (FR4.2).
+- **BR13**: An optional `arg` (path or ref) is passed straight through to `git diff [arg]`; omitted/empty `arg` runs a plain `git diff`.
+- **BR14**: `git diff`'s own error output (non-git-repo, invalid ref, etc.) becomes the tool's returned error text verbatim - no special-casing of "not a repository" versus other git errors, since git's own message is already clear (FR4.3).
+- **BR15**: Same 30-second timeout as `run_shell`, for consistency, though not expected to matter in practice for a diff operation.
+
+## Shared
+- **BR16**: All 3 tools' JSON input is unmarshaled independently in each method that needs it (`ConfirmationSummary`, `Execute`) - no shared parsed-input cache between the two calls, consistent with BR3's independence principle.

--- a/aidlc-docs/construction/unit-7-new-tools/functional-design/domain-entities.md
+++ b/aidlc-docs/construction/unit-7-new-tools/functional-design/domain-entities.md
@@ -1,0 +1,49 @@
+# Functional Design: Domain Entities - Unit 7, New Built-in Tools (#86)
+
+## `utils/utils.go` (modified - additive)
+```go
+func ValidateLocalPathForWrite(filename string) (string, error)
+```
+Shares a new private `confineToWorkingDir(filename string) (string, error)` helper with the existing `ValidateLocalPath`, which is refactored internally to call it plus its own existence check. `ValidateLocalPath`'s public contract/behavior is unchanged.
+
+## `tools/writefile.go` (new)
+```go
+type WriteFileTool struct{}
+func NewWriteFileTool() *WriteFileTool
+func (t *WriteFileTool) Name() string // "write_file"
+func (t *WriteFileTool) Description() string
+func (t *WriteFileTool) InputSchema() document.Interface // {"path": string, "content": string}
+func (t *WriteFileTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+func (t *WriteFileTool) RequiresConfirmation() bool // true
+func (t *WriteFileTool) ConfirmationSummary(input json.RawMessage) (summary, patternKey string, err error)
+```
+
+## `tools/runshell.go` (new)
+```go
+const runShellTimeout = 30 * time.Second
+const maxShellOutputSize = 32 * 1024
+
+type RunShellTool struct{}
+func NewRunShellTool() *RunShellTool
+func (t *RunShellTool) Name() string // "run_shell"
+func (t *RunShellTool) Description() string
+func (t *RunShellTool) InputSchema() document.Interface // {"command": string}
+func (t *RunShellTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+func (t *RunShellTool) RequiresConfirmation() bool // true
+func (t *RunShellTool) ConfirmationSummary(input json.RawMessage) (summary, patternKey string, err error)
+```
+
+## `tools/gitdiff.go` (new)
+```go
+type GitDiffTool struct{}
+func NewGitDiffTool() *GitDiffTool
+func (t *GitDiffTool) Name() string // "git_diff"
+func (t *GitDiffTool) Description() string
+func (t *GitDiffTool) InputSchema() document.Interface // {"arg": string, optional}
+func (t *GitDiffTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+func (t *GitDiffTool) RequiresConfirmation() bool // false
+func (t *GitDiffTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) // unused, never called
+```
+
+## `cmd/chat.go` (modified)
+Registers the 3 new tools alongside the existing `tools.NewReadFileTool()` registration, still gated by `toolsEnabled` (Unit 8 removes that gate, not this unit).

--- a/aidlc-docs/construction/unit-7-new-tools/nfr-requirements/nfr-requirements-and-design.md
+++ b/aidlc-docs/construction/unit-7-new-tools/nfr-requirements/nfr-requirements-and-design.md
@@ -1,0 +1,45 @@
+# NFR Requirements and Design (Combined): Unit 7, New Built-in Tools (#86)
+
+Combined presentation, same pattern as Unit 6. Security remains dominant - these are the tools Unit 6's gate exists to protect against.
+
+## Security
+
+### Requirement
+`write_file` must stay confined to the working directory exactly like `read_file`. `run_shell` has no path confinement to speak of (arbitrary commands), so the confirmation gate (Unit 6) is the entire control - this unit must not weaken that by, say, executing before the gate is consulted.
+
+### Design
+- `write_file` reuses the exact same confinement algorithm as `read_file`/`--document`/`--image` (`ValidateLocalPathForWrite`, sharing `confineToWorkingDir` with `ValidateLocalPath`) - no new traversal-safety logic invented for this unit.
+- Both `WriteFileTool.Execute` and `RunShellTool.Execute` are only ever reachable through `Registry.Dispatch`, which (per Unit 6) always consults the gate first since both declare `RequiresConfirmation() == true`. Nothing in this unit calls `Execute` directly.
+- `run_shell`'s lack of a command allowlist (Requirements Analysis Assumption 2) is a deliberate, already-approved tradeoff - re-flagged here rather than silently accepted, since it's the single highest-risk capability added in this entire initiative. The gate (once/session/always/deny, per-base-command pattern matching) is the sole mitigation.
+- `git_diff` has no destructive capability at all (it can only read repository state) - Security review for it is limited to "does it accept arbitrary flags that could do something unexpected" - it does not; only a single positional `arg` is passed, never interpreted as multiple shell tokens (passed as one `exec.Command` argument, not through a shell that could split/reinterpret it - see Reliability below for why this also matters there).
+
+### Compliance
+✅ Compliant - `write_file` reuses proven confinement logic; `run_shell`'s risk is explicitly the gate's job, not this unit's; `git_diff` has no meaningful attack surface.
+
+## Reliability
+
+### Requirement
+`run_shell` must not hang `chat` indefinitely, and a failing command (bad exit code) must not be indistinguishable from a tool-implementation bug.
+
+### Design
+- BR8: a hard 30-second timeout via `context.WithTimeout`, always applied - no way for a single `run_shell` call to hang the session forever.
+- BR10: a non-zero exit code flows back to the model as normal tool output (with the exit code visible), not as a Go error - keeps the important reliability distinction between "the tool itself is broken" (a real Go error: failed to start `sh`, timeout) and "the command the model chose to run didn't succeed" (expected, normal operation, the model should just see it and adapt).
+- `git_diff`'s `arg` is passed as a single `exec.Command` argument (not concatenated into a shell string) - this isn't just security, it's reliability too: a ref/path containing spaces or shell metacharacters behaves as literal text, not as multiple arguments or shell syntax, so `git diff` gets exactly what the model asked for.
+
+### Compliance
+✅ Compliant - bounded execution time, and a clear, non-error-based signal for the very common "command failed" case.
+
+## Usability
+
+### Requirement
+Same as Unit 6's carried-forward NFR5: the confirmation summary must be informative without flooding the terminal.
+
+### Design
+- `write_file`'s summary truncates content past 4KB with an explicit note (BR4), same threshold and rationale as Unit 6's NFR design.
+- `run_shell`'s summary is simply the exact command string - already inherently compact, no truncation needed at the confirmation stage (the *output*, not the confirmation prompt, is where truncation applies - BR9, and that's shown after the fact, not at the gate).
+
+### Compliance
+✅ Compliant.
+
+## Non-Applicable Categories
+- **Scalability/Performance/Availability**: N/A, same rationale as every prior unit - single local process. `run_shell`'s 30s cap is a reliability bound, not a performance target.

--- a/aidlc-docs/construction/unit-8-automatic-enablement/code/summary.md
+++ b/aidlc-docs/construction/unit-8-automatic-enablement/code/summary.md
@@ -1,0 +1,24 @@
+# Code Generation Summary: Unit 8, Automatic Tool-Use Enablement (#86) - Final Unit
+
+## Files Modified
+- `cmd/inferenceconfig.go` - new `isToolUseUnsupportedError` (heuristic, unverified against real Bedrock error text); a third cascading-retry stage added to `converseStreamWithFallbacks` (chat-only - `converseWithFallbacks`, the `prompt`-only sibling, is untouched since tool use has never applied to `prompt`)
+- `cmd/inferenceconfig_test.go` - new `TestIsToolUseUnsupportedError`, mirroring the existing `TestIsDeprecatedSamplingParamsError` table-driven style
+- `cmd/root.go` - `--tools` flag registration removed
+- `cmd/chat.go` - `toolsEnabled` flag-read and the `if toolsEnabled { ... }` gate removed; all 4 tools now registered unconditionally
+
+## Design Notes
+- No unit test was added for the new retry branch inside `converseStreamWithFallbacks` itself - it calls the real, unmockable `*bedrockruntime.Client`, matching the established precedent already set by the cache-point and sampling-params fallback stages (neither of which has a mocked-client test either).
+- "Disabled for the rest of the session" (FR1.2) required no new code beyond the fallback itself: `converseStreamInput` is built once per `chat` session and mutated across every turn in the existing loop, so `input.ToolConfig = nil` on one rejected request persists automatically for all subsequent turns.
+
+## Manual Verification (no AWS credentials needed)
+1. `chat-cli --help | grep -i tools` → zero matches, confirming `--tools` is fully gone
+2. Constructed the real `tools.Registry` exactly as `cmd/chat.go` now does (no flag involved) and confirmed `ToolConfiguration()` always returns all 4 registered tools
+
+## Test Results
+- `make test`: all packages pass, no regressions
+- `make lint`: clean
+- Coverage: `cmd` 33.1%→33.5%, total 71.2%→70.9% (negligible dip - the new fallback branch isn't directly unit-tested, per the established precedent noted above; no other package changed)
+- `go test -tags=integration -v .`: 7/7 pass
+
+## Initiative 3 (#86) - All 3 Units Complete
+Unit 6 (Confirmation and Sticky Approval Engine) → Unit 7 (New Built-in Tools) → Unit 8 (Automatic Tool-Use Enablement, this unit) are all code-complete. Proceeding to the initiative-wide Build and Test stage next, covering all 3 units together per `core-workflow.md`'s Per-Unit Loop.

--- a/aidlc-docs/construction/unit-8-automatic-enablement/functional-design/business-logic-model.md
+++ b/aidlc-docs/construction/unit-8-automatic-enablement/functional-design/business-logic-model.md
@@ -1,0 +1,36 @@
+# Functional Design (Combined with NFR): Unit 8, Automatic Tool-Use Enablement (#86)
+
+Lower novelty than Units 6-7 - this unit extends an already-established, already-tested pattern (`cmd/inferenceconfig.go`'s cascading fallback retries) rather than introducing anything new. Verified against the actual current source, not assumed.
+
+## The Existing Pattern (verified)
+`converseStreamWithFallbacks` (`cmd/inferenceconfig.go:95`) already does exactly this shape of thing twice: try the request, and on failure, check if a specific optional field was present (`hasSystemCachePoint`/`hasContentCachePoint`, or a deprecated-sampling-params error match), strip it, retry once, log a `log.Printf` notice either way. This is the *only* function on chat's send path (chat always streams; `converseWithFallbacks`, the non-streaming sibling, is `prompt`-only and is **not** touched by this unit, since tool use has never applied to `prompt`).
+
+## Design: Add a Third Fallback Stage
+Insert a tool-use-rejection check between the existing cache-point and deprecated-sampling-params stages:
+```go
+if input.ToolConfig != nil && isToolUseUnsupportedError(err) {
+    log.Printf("tool use not supported for this model, retrying without tools: %v", err)
+    input.ToolConfig = nil
+    output, err = svc.ConverseStream(ctx, input)
+    if err == nil { return output, nil }
+}
+```
+- The `input.ToolConfig != nil` guard mirrors `hasSystemCachePoint(...)`'s role - never attempt a pointless retry when there's nothing to strip.
+- **"Disabled for the rest of the session" (FR1.2) falls out for free**: `converseStreamInput` is built once per `chat` session and mutated across turns (the existing `for` loop appends to `.Messages` on the same struct rather than rebuilding it). Setting `input.ToolConfig = nil` here persists across every subsequent turn automatically - no new session-state tracking needed, the same mechanism the cache/sampling-params fallbacks already rely on.
+- **The FR1.3 user-visible notice is the existing `log.Printf` call itself** - it already goes to stderr and is how every other fallback in this function already surfaces itself. Reusing this convention satisfies "a clear, one-line notice" without inventing new UI styling for one code path.
+
+## `isToolUseUnsupportedError` - Flagged as an Unverified Assumption
+**This is the highest-risk assumption in this unit**, the same category of uncertainty Initiative 1's Unit 5 had for `reasoning_config`'s shape: there is no way to statically verify Bedrock's exact error text for "this model/request doesn't support tool use" without live credentials. Designed as a heuristic, matching `isDeprecatedSamplingParamsError`'s existing style:
+```go
+func isToolUseUnsupportedError(err error) bool {
+    if err == nil { return false }
+    msg := strings.ToLower(err.Error())
+    if !strings.Contains(msg, "tool") { return false }
+    return strings.Contains(msg, "not supported") || strings.Contains(msg, "does not support") || strings.Contains(msg, "unsupported")
+}
+```
+Flagged prominently for the real-credential verification list (same list Unit 5's `reasoning_config` shape is already on).
+
+## `--tools` Removal
+- `cmd/root.go`: the `rootCmd.PersistentFlags().Bool("tools", false, ...)` registration is deleted.
+- `cmd/chat.go`: the `toolsEnabled` flag-read and the `if toolsEnabled { ... }` gate around tool registration are both removed - registration becomes unconditional (all 4 tools always registered).

--- a/aidlc-docs/construction/unit-8-automatic-enablement/nfr-requirements/nfr-requirements-and-design.md
+++ b/aidlc-docs/construction/unit-8-automatic-enablement/nfr-requirements/nfr-requirements-and-design.md
@@ -1,0 +1,20 @@
+# NFR Requirements and Design (Combined): Unit 8, Automatic Tool-Use Enablement (#86)
+
+## Reliability
+
+### Requirement
+Removing the `--tools` opt-in must not make `chat` break for any model that doesn't support tool use - this is the entire point of FR1.2's retry-without-tools fallback, and it's the most important property in this unit.
+
+### Design
+- The fallback reuses `converseStreamWithFallbacks`'s already-tested cascading-retry shape - same function, same error-handling conventions, same "strip and retry once" policy already proven correct for cache points and sampling params.
+- `isToolUseUnsupportedError`'s exact string-matching heuristic is unverified against real Bedrock error text (flagged in the functional design) - if it under-matches (misses a real rejection message), the practical failure mode is "the retry doesn't trigger and the original error surfaces to the user," not a crash or hang. This is a *graceful* degradation of the *fallback itself*, not a new failure mode - acceptable risk, consistent with how `isDeprecatedSamplingParamsError` shipped with the same category of uncertainty.
+
+### Compliance
+✅ Compliant, with a flagged unverified assumption (heuristic error matching) carried to the real-credential verification list, not silently accepted as certain.
+
+## Backward Compatibility (revised, per Initiative 3's Requirements Analysis)
+This unit is the one that actually executes the intentional default-behavior change agreed in Requirements Analysis (Assumption 7): `chat` now always attempts tool use, where it previously required `--tools`. This is not a regression to guard against - it's the deliberate deliverable of this unit, already explicitly approved.
+
+## Non-Applicable Categories
+- **Security**: N/A for this unit specifically - the security-relevant work (confinement, the confirmation gate) is Units 6/7's job; this unit is pure wiring/retry-logic.
+- **Scalability/Performance/Availability/Usability**: N/A, same rationale as every prior unit.

--- a/aidlc-docs/inception/application-design/application-design.md
+++ b/aidlc-docs/inception/application-design/application-design.md
@@ -25,3 +25,31 @@ This document consolidates `components.md`, `component-methods.md`, `services.md
 - No component introduces a circular dependency (see `component-dependency.md`'s matrix — all new components depend only on existing `utils`/stdlib, never the reverse).
 - No component duplicates the path-safety logic already in `utils.ReadImage` — it's extracted and shared instead (directly addresses the pattern flagged as a risk in `code-quality-assessment.md`'s "Duplicated model-validation logic" finding, applied here proactively to file-path validation).
 - No new component touches `db`/`db/sqlite`/`factory` — confirms the "no data model changes" call in `execution-plan.md`.
+
+---
+
+# Initiative 3 Application Design (Consolidated, #86)
+
+**Scope**: Extends the tool-use subsystem from Initiative 1 (`tools.Tool`/`Registry`) with 3 new tools and a genuinely new permission-engine subsystem (`PermissionGate`, `ApprovalStore`, `InteractivePermissionGate`), plus wiring changes to `cmd/chat.go` (automatic enablement, `--tools` removal, retry-without-tools). Unlike Initiative 2, this warranted full Application Design treatment given the real new architecture involved — see `builtin-tools-execution-plan.md` for the risk-based rationale.
+
+This section summarizes; see `components.md`, `component-methods.md`, `services.md`, `component-dependency.md` (each has an "Initiative 3" section appended) for full detail.
+
+## New Components (summary)
+1. **Extended `tools.Tool` interface** — adds `RequiresConfirmation()`/`ConfirmationSummary()`.
+2. **`tools.WriteFileTool`, `tools.RunShellTool`, `tools.GitDiffTool`** — the 3 new built-in tools.
+3. **`tools.PermissionGate`** (interface) + **`tools.ApprovalStore`** — the abstract permission-decision contract and its session/persisted-tier bookkeeping.
+4. **`cmd.InteractivePermissionGate`** — the concrete terminal-prompting implementation.
+5. **`utils.FindGitBoundary`** (extracted) — shared repo-root detection, reused by both `tools.ApprovalStore` (new) and `cmd/projectcontext.go` (#88, refactored from a private copy).
+
+## Extended (Not Redesigned) Components
+- `tools.Registry.Dispatch` — signature gains a `PermissionGate` parameter, consulted before any destructive tool's `Execute`.
+- `cmd/chat.go` — `--tools` flag removed; registry/gate construction and the retry-without-tools fallback added to the existing orchestration.
+
+## What's Explicitly Deferred
+- Exact confirmation-prompt UI text, the persisted-store's file format/location, and `run_shell`'s exact timeout/output-cap values → per-unit **Functional Design** in Construction.
+- Whether the interactive prompt itself is unit-testable via an injected reader, or needs a documented manual-verification gap → decided in the Permission Engine unit's Functional Design.
+
+## Consistency Check
+- `tools` still does not import `cmd` — the one component that would have needed it (`ApprovalStore`'s repo-boundary detection) is resolved via extracting the logic to `utils` instead, preserving the existing one-directional dependency shape (`cmd` → `tools`, never the reverse).
+- The extraction of `utils.FindGitBoundary` is the only change to already-shipped Initiative 2 code in this whole initiative — flagged explicitly, not incidental.
+- No new component touches `db`/`db/sqlite`/`factory`/`repository`/`config` — this initiative is fully contained within `tools`/`cmd`/one `utils` extraction.

--- a/aidlc-docs/inception/application-design/component-dependency.md
+++ b/aidlc-docs/inception/application-design/component-dependency.md
@@ -57,3 +57,64 @@ repository.ChatRepository -> db.Database (unchanged)
 ## Communication Patterns
 - All calls are synchronous, in-process Go function calls — no new IPC, no new network boundaries, no new goroutine coordination beyond what `ProcessStreamingOutput` already does for streaming.
 - `tools.Registry.Dispatch` returns a Bedrock content block value (not an error propagated up the call stack) by design — tool failures are conversation-level events the model should see and can respond to (FR2.3), not CLI-level fatal errors.
+
+---
+
+# Initiative 3 Dependencies (#86)
+
+## Dependency Matrix
+
+| Component | Depends On | Depended On By |
+|---|---|---|
+| `cmd/chat.go` (extended) | `tools.Registry` (now 4 tools), `cmd.InteractivePermissionGate`, `tools.ApprovalStore`, `utils.FindGitBoundary` | (entry point) |
+| `tools.Registry.Dispatch` (extended) | `tools.Tool` (extended interface), `tools.PermissionGate` | `cmd/chat.go` |
+| `tools.WriteFileTool` | `tools.Tool` interface, `utils.ValidateLocalPath` | `tools.Registry` |
+| `tools.RunShellTool` | `tools.Tool` interface, standard library (`os/exec`) | `tools.Registry` |
+| `tools.GitDiffTool` | `tools.Tool` interface, standard library (`os/exec`) | `tools.Registry` |
+| `tools.PermissionGate` (interface) | none | `tools.Registry.Dispatch`, `cmd.InteractivePermissionGate` (implements it) |
+| `tools.ApprovalStore` | `utils.FindGitBoundary` | `cmd.InteractivePermissionGate` |
+| `utils.FindGitBoundary` (extracted) | standard library (`os`, `path/filepath`) | `tools.ApprovalStore`, `cmd/projectcontext.go` (refactored to reuse it instead of its private copy) |
+| `cmd.InteractivePermissionGate` | `tools.PermissionGate` interface, `tools.ApprovalStore` | `cmd/chat.go` |
+
+No changes to: `db`, `db/sqlite`, `factory`, `repository`, `config` — this initiative is entirely within `tools`/`cmd`/one `utils` extraction.
+
+## Dependency Diagram
+
+```mermaid
+flowchart TD
+    chatCmd2["cmd/chat.go"] --> registry2["tools.Registry (4 tools)"]
+    chatCmd2 --> gate["cmd.InteractivePermissionGate"]
+
+    registry2 --> toolIface2["tools.Tool (extended)"]
+    registry2 --> gateIface["tools.PermissionGate"]
+
+    writeTool["tools.WriteFileTool"] --> toolIface2
+    writeTool --> validatePath2["utils.ValidateLocalPath (existing)"]
+    shellTool["tools.RunShellTool"] --> toolIface2
+    diffTool["tools.GitDiffTool"] --> toolIface2
+
+    registry2 -.->|"registers"| writeTool
+    registry2 -.->|"registers"| shellTool
+    registry2 -.->|"registers"| diffTool
+
+    gate --> gateIface
+    gate --> approvalStore["tools.ApprovalStore"]
+    approvalStore --> gitBoundary["utils.FindGitBoundary (extracted)"]
+
+    projectContext["cmd/projectcontext.go (#88, refactored)"] --> gitBoundary
+```
+
+### Text Alternative
+```
+cmd/chat.go -> tools.Registry (4 tools), cmd.InteractivePermissionGate
+tools.Registry.Dispatch -> tools.Tool (extended), tools.PermissionGate
+tools.WriteFileTool/RunShellTool/GitDiffTool -> tools.Tool interface
+tools.WriteFileTool -> utils.ValidateLocalPath (existing, reused)
+cmd.InteractivePermissionGate -> tools.PermissionGate, tools.ApprovalStore
+tools.ApprovalStore -> utils.FindGitBoundary (extracted from #88's cmd/projectcontext.go)
+cmd/projectcontext.go -> utils.FindGitBoundary (refactored to reuse, was private findGitBoundary)
+```
+
+## Communication Patterns (Initiative 3)
+- `Registry.Dispatch`'s permission check is synchronous and blocking, same execution model as everything else in the tty-loop — `InteractivePermissionGate.Check` reads from stdin directly, no new goroutines.
+- `ApprovalStore`'s persisted tier does file I/O only on a `RecordAlways` call (write) and once at construction (read) — not on every `IsApproved` lookup, which stays in-memory after initial load.

--- a/aidlc-docs/inception/application-design/component-methods.md
+++ b/aidlc-docs/inception/application-design/component-methods.md
@@ -80,3 +80,106 @@ func ReadDocument(filename string) (data []byte, format string, err error)
 // validates via ValidateLocalPath, checks against the supported-format allow-list
 // (pdf, csv, doc, docx, xls, xlsx, html, txt, md), returns bytes + detected format
 ```
+
+---
+
+# Initiative 3 Component Methods (#86)
+
+## `tools.Tool` (interface, extended)
+
+```go
+type Tool interface {
+    Name() string
+    Description() string
+    InputSchema() document.Interface
+    Execute(ctx context.Context, input json.RawMessage) (result string, err error)
+
+    // New:
+    RequiresConfirmation() bool
+    // ConfirmationSummary returns human-readable text describing what this
+    // specific call will do (for the prompt), and a coarse pattern key used
+    // for sticky-approval matching (base command for run_shell, directory
+    // for write_file). Only meaningful when RequiresConfirmation() is true.
+    ConfirmationSummary(input json.RawMessage) (summary string, patternKey string, err error)
+}
+```
+
+- `read_file`/`git_diff`: `RequiresConfirmation()` returns `false`; `ConfirmationSummary` is unused (never called by `Dispatch` for a non-destructive tool).
+
+## `tools.Registry` (extended)
+
+```go
+func (r *Registry) Dispatch(ctx context.Context, call ToolCall, gate PermissionGate) types.ToolResultBlock
+```
+
+- Before calling `Execute`, if `tool.RequiresConfirmation()`, calls `tool.ConfirmationSummary(call.Input)` then `gate.Check(tool.Name(), patternKey, summary)`. A `Deny` decision short-circuits to a declined-action error `ToolResultBlock` (FR5.3) without calling `Execute`.
+
+## `tools.PermissionGate` (new interface)
+
+```go
+type Decision int
+const (
+    DecisionAllowOnce Decision = iota
+    DecisionAllowSession
+    DecisionAllowAlways
+    DecisionDeny
+)
+
+type PermissionGate interface {
+    // Check returns a decision for this specific call. Implementations may
+    // block on user input; a prior session/always approval matching
+    // toolName+patternKey short-circuits without prompting.
+    Check(toolName, patternKey, summary string) Decision
+}
+```
+
+## `tools.ApprovalStore` (new)
+
+```go
+type ApprovalStore struct { /* unexported: in-memory session set + persisted-tier backing */ }
+
+func NewApprovalStore(repoRoot string) (*ApprovalStore, error)
+func (s *ApprovalStore) IsApproved(toolName, patternKey string) bool
+func (s *ApprovalStore) RecordSession(toolName, patternKey string)
+func (s *ApprovalStore) RecordAlways(toolName, patternKey string) error // persists
+```
+
+## `tools.WriteFileTool`, `tools.RunShellTool`, `tools.GitDiffTool` (new)
+
+```go
+type WriteFileTool struct{}
+func NewWriteFileTool() *WriteFileTool
+func (t *WriteFileTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+// unmarshals {"path": "...", "content": "..."}, validates via utils.ValidateLocalPath, writes
+
+type RunShellTool struct{}
+func NewRunShellTool() *RunShellTool
+func (t *RunShellTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+// unmarshals {"command": "..."}, runs via sh -c with a timeout, returns combined truncated output
+
+type GitDiffTool struct{}
+func NewGitDiffTool() *GitDiffTool
+func (t *GitDiffTool) Execute(ctx context.Context, input json.RawMessage) (string, error)
+// unmarshals {"arg": "..."} (optional), runs `git diff [arg]`, returns raw output or a clear error
+```
+
+## `utils.FindGitBoundary` (new exported function, extracted from `cmd/projectcontext.go`)
+
+```go
+func FindGitBoundary(dir string) string
+// identical behavior to #88's private findGitBoundary: walks upward from dir
+// (stat-only, capped at 64 levels) looking for the first ancestor containing
+// a .git entry; returns "" if none found. cmd/projectcontext.go is refactored
+// to call this instead of its own private copy.
+```
+
+## `cmd.InteractivePermissionGate` (new, implements `tools.PermissionGate`)
+
+```go
+type InteractivePermissionGate struct { /* unexported: *tools.ApprovalStore */ }
+
+func NewInteractivePermissionGate(store *tools.ApprovalStore) *InteractivePermissionGate
+func (g *InteractivePermissionGate) Check(toolName, patternKey, summary string) tools.Decision
+// prints the summary, blocks reading a once/session/always/deny choice,
+// records session/always decisions into the store, returns the decision
+```

--- a/aidlc-docs/inception/application-design/components.md
+++ b/aidlc-docs/inception/application-design/components.md
@@ -32,3 +32,43 @@ Scope: only genuinely new/reusable components introduced by issues #81-#85. Syst
 - **`config.FileManager`** — gains one new supported config key (`system-prompt`), using the exact same `GetConfigValue` precedence mechanism already in place for `model-id`/`custom-arn`. No interface change.
 - **`repository.ChatRepository`** — used as-is; tool-call turns persist through the existing `Create` method with existing `Persona` values (FR2.4). No interface change.
 - **`cmd/prompt.go`'s attachment handling** — gains a document-attachment code path parallel to the existing image-attachment path (FR4.1), built on `utils.ValidateLocalPath` and a new `ContentBlockMemberDocument` builder. Not a new component — an extension of existing command logic (see `services.md`).
+
+---
+
+# Initiative 3 Components (#86)
+
+Scope: extends the `Tool`/`Registry` components above (Initiative 1 Unit 2) with 3 new tools and a genuinely new permission-engine subsystem. Verified against the current `tools/tool.go`/`tools/registry.go` source, not assumed.
+
+## Component: Extended `Tool` Interface
+- **Purpose**: Let a tool declare whether it's destructive and, if so, how to summarize a specific call for the confirmation prompt and derive its coarse sticky-approval pattern key.
+- **Responsibilities**: Two new methods alongside the 4 existing ones (`Name`, `Description`, `InputSchema`, `Execute`). `read_file`/`git_diff` implement them as no-ops (non-destructive); `write_file`/`run_shell` implement them for real (FR5.1, FR6.1-FR6.2).
+- **Package**: `tools` (existing package, interface extended)
+
+## Component: `WriteFileTool`, `RunShellTool`, `GitDiffTool`
+- **Purpose**: The 3 new built-in tools (FR2-FR4).
+- **Responsibilities**: `WriteFileTool` creates/overwrites a file within the working directory (reuses `utils.ValidateLocalPath`), destructive. `RunShellTool` runs a shell command with a timeout and output cap, destructive. `GitDiffTool` runs `git diff [arg]`, read-only, non-destructive.
+- **Package**: `tools` (new files), each implements the extended `Tool` interface, following `ReadFileTool`'s existing shape
+
+## Component: `PermissionGate` (interface)
+- **Purpose**: The abstract contract for "decide whether a destructive call may proceed" (FR5, FR6) - decouples the decision from how it gets made.
+- **Responsibilities**: Defines a `Check` operation and `Decision` result type (allow/deny). `Registry.Dispatch` is extended to accept a `PermissionGate` and consult it before executing a tool that `RequiresConfirmation()`.
+- **Package**: `tools` (new)
+
+## Component: `ApprovalStore`
+- **Purpose**: Tracks granted sticky approvals at the session tier (in-memory) and the "always" tier (persisted per git repository) (FR6.3, FR7).
+- **Responsibilities**: Pure lookup/record logic - no I/O beyond its own persisted-tier backing file, no prompting/UI (that's `InteractivePermissionGate`). Uses the shared git-boundary helper below to scope "always" approvals per repository.
+- **Package**: `tools` (new)
+
+## Component: Shared Git-Boundary Helper (extracted to `utils`)
+- **Purpose**: `ApprovalStore` needs the same repo-root-detection behavior #88 already built (`findGitBoundary`, currently private inside `cmd/projectcontext.go`), but `tools` cannot import `cmd` (import cycle - `cmd` already imports `tools`).
+- **Decision**: Extract the boundary-walk logic into a new exported `utils.FindGitBoundary(dir string) string`; refactor `cmd/projectcontext.go` to call it instead of keeping a private copy. Justified refactor of already-shipped Initiative 2 code - avoids duplicating logic that's already had one real bug found and fixed in it (Initiative 2's epilogue commit).
+- **Package**: `utils` (existing package, new exported function; `cmd/projectcontext.go` refactored to call it)
+
+## Component: `InteractivePermissionGate`
+- **Purpose**: The concrete, terminal-facing `PermissionGate` implementation - shows the confirmation prompt, reads the once/session/always/deny choice, records it via `ApprovalStore`.
+- **Responsibilities**: Owns all user-facing I/O for this initiative - consistent with the existing split where `tools/` holds abstract contracts and `cmd/` holds concrete terminal orchestration (mirrors `cmd/toolloop.go`'s relationship to `tools.Registry`).
+- **Package**: `cmd` (new)
+
+## Existing Components Extended (Initiative 3)
+- **`cmd/chat.go`** — tool-enablement wiring changes: always builds the registry (now 4 tools) and an `InteractivePermissionGate`; the `--tools` flag is removed; a retry-without-tools-on-rejection fallback is added, mirroring `cmd/promptcache.go`'s existing cache-point retry pattern (FR1).
+- **`tools.Registry.Dispatch`** — signature extended to accept a `PermissionGate`, consulted before executing any tool where `RequiresConfirmation()` is true.

--- a/aidlc-docs/inception/application-design/services.md
+++ b/aidlc-docs/inception/application-design/services.md
@@ -55,3 +55,44 @@ promptCmd.Run:
   -> send request (cache-point wrapped) -> print response
   (no tool-use orchestration in prompt)
 ```
+
+---
+
+# Initiative 3 Service Changes (#86)
+
+## Service: `chatCmd.Run` (`cmd/chat.go`, extended again)
+
+- **Orchestration changes**:
+  - `--tools` flag removed; the registry is always built (now with 4 tools: `read_file`, `write_file`, `run_shell`, `git_diff`) and `ToolConfiguration()` is always attached (FR1.1, FR1.4).
+  - An `InteractivePermissionGate` (backed by an `ApprovalStore` scoped to the current repo root via `utils.FindGitBoundary`) is constructed once per session and passed into every `Registry.Dispatch` call (FR5-FR7).
+  - The Converse/ConverseStream call is wrapped with a new retry-without-`ToolConfiguration`-on-rejection policy, structurally identical to `cmd/promptcache.go`'s existing cache-point retry wrapper (FR1.2) — on success after retry, prints the FR1.3 notice.
+- **Orchestration pattern unchanged**: still the same sequential, single-threaded tty-loop; the permission check happens synchronously inside `Dispatch`, blocking the loop exactly the way a tool's `Execute` already blocks it today — no new concurrency.
+
+## Orchestration Diagram (Initiative 3 addition)
+
+```mermaid
+flowchart TD
+    ChatRun["chatCmd.Run"] --> BuildRegistry2["Build tools.Registry<br/>(4 tools, always)"]
+    ChatRun --> BuildGate["Build InteractivePermissionGate<br/>+ ApprovalStore (repo-scoped)"]
+    ChatRun --> SendReq3["Send request<br/>(tools attached, cache-point wrapped)"]
+    SendReq3 -->|"rejected: tool-use unsupported"| RetryNoTools["Retry once without<br/>ToolConfiguration"]
+    RetryNoTools --> NoticeTools["Print: tools disabled this session"]
+    SendReq3 -->|"ToolUseBlock in response"| Dispatch2["Registry.Dispatch(call, gate)"]
+    Dispatch2 -->|"tool.RequiresConfirmation()"| GateCheck["gate.Check(...)"]
+    GateCheck -->|"deny"| DeclineResult["Declined ToolResultBlock"]
+    GateCheck -->|"allow (once/session/always)"| Execute3["tool.Execute(...)"]
+    Dispatch2 -->|"not destructive"| Execute3
+    Execute3 --> AppendResult2["Append ToolResultBlock, continue stream"]
+```
+
+### Text Alternative
+```
+chatCmd.Run (Initiative 3):
+  build tools.Registry (4 tools, always) -> build InteractivePermissionGate (repo-scoped ApprovalStore)
+  -> send request (tools attached)
+     -> if rejected for unsupported tool use: retry once without ToolConfiguration, notify user
+     -> if ToolUseBlock in response: Dispatch(call, gate)
+        -> if tool.RequiresConfirmation(): gate.Check(...) -> deny: declined result | allow: Execute
+        -> if not destructive: Execute directly
+        -> append ToolResultBlock, continue stream
+```

--- a/aidlc-docs/inception/application-design/unit-of-work-dependency.md
+++ b/aidlc-docs/inception/application-design/unit-of-work-dependency.md
@@ -33,3 +33,34 @@ This is the same 1-2-3-4-5 order already recommended in `requirements.md` and `e
 ## Coordination Points
 - **Shared code**: `utils.ValidateLocalPath` (introduced by Unit 2 or Unit 4, whichever lands first) and the cache-point helper (Unit 3) are the only cross-unit shared artifacts. Both are additive utility functions — no unit needs to modify another unit's code to integrate with them, only call them.
 - **No shared mutable state**: Each unit's flags/config keys are independent; a user can combine `--system`, `--thinking`, `--document`, and tool-use in a single `chat` invocation without the units having coordinated on request-building order beyond "system prompt block, then content blocks, then tool config" (standard Converse request shape).
+
+---
+
+# Initiative 3 Dependencies (#86)
+
+Unlike Initiative 1's units (mostly independent), Unit 7 has a **hard** dependency here — it needs Unit 6's extended `Tool` interface and `PermissionGate` to compile against, not just a "nicer if it exists first" recommendation.
+
+## Dependency Matrix
+
+| Unit | Depends On | Reason | Hard or Soft |
+|---|---|---|---|
+| Unit 6 — Confirmation and Sticky Approval Engine | None | Foundational - defines the extended `Tool` interface and `PermissionGate` everything else builds on | — |
+| Unit 7 — New Built-in Tools | Unit 6 | `WriteFileTool`/`RunShellTool` must implement `RequiresConfirmation()`/`ConfirmationSummary()` from the extended interface, and `Registry.Dispatch` (extended in Unit 6) must exist to gate them | **Hard** |
+| Unit 8 — Automatic Tool-Use Enablement | Unit 6 + Unit 7 (recommended) | `chat.go`'s "always build the full registry + gate" wiring is most coherent to write once the full tool set and gate exist, though the retry-without-tools logic itself doesn't technically require them | Soft |
+
+## Recommended Build Order
+
+```mermaid
+flowchart LR
+    U6["Unit 6<br/>Confirmation Engine"] --> U7["Unit 7<br/>New Tools"]
+    U7 --> U8["Unit 8<br/>Automatic Enablement"]
+```
+
+### Text Alternative
+```
+Unit 6 (Confirmation Engine) -> Unit 7 (New Tools) -> Unit 8 (Automatic Enablement)
+```
+
+## Coordination Points
+- **Shared code**: `utils.FindGitBoundary` (extracted in Unit 6) is used by Unit 6's own `ApprovalStore` and, separately, refactored into `cmd/projectcontext.go` (#88) - a one-time extraction, not an ongoing coordination point.
+- **The only hard dependency in this entire session's work so far**: Unit 7 literally cannot compile until Unit 6's interface extension lands - this must be enforced in build order, not just recommended.

--- a/aidlc-docs/inception/application-design/unit-of-work-story-map.md
+++ b/aidlc-docs/inception/application-design/unit-of-work-story-map.md
@@ -18,3 +18,26 @@ Every story from `aidlc-docs/inception/user-stories/stories.md` is assigned to e
 - **Units with no stories**: 0
 
 Cross-cutting NFRs (NFR1 backward compatibility, NFR2 TDD/coverage, NFR4 error handling, NFR5 no new deps, NFR6 docs, NFR7 streaming compatibility) apply to all 6 stories/5 units and are re-verified per-unit during Build and Test, not owned by any single unit.
+
+---
+
+# Initiative 3 Story Map (#86)
+
+| Story | Unit | FR/NFR IDs | Issue |
+|---|---|---|---|
+| 8.1 — First-time confirmation for a destructive call | Unit 6 — Confirmation Engine | FR5.1-FR5.2 | #86 |
+| 8.2 — Sticky approval is remembered and reused | Unit 6 — Confirmation Engine | FR5.2, FR6.1-FR6.3, FR7.1-FR7.2 | #86 |
+| 8.3 — Denying a destructive call | Unit 6 — Confirmation Engine | FR5.2-FR5.3 | #86 |
+| 7.1 — Model edits a local file | Unit 7 — New Tools | FR2.1-FR2.3, NFR1 | #86 |
+| 7.2 — Model runs a shell command | Unit 7 — New Tools | FR3.1-FR3.2, NFR2 | #86 |
+| 7.3 — Model inspects the working tree diff | Unit 7 — New Tools | FR4.1-FR4.3 | #86 |
+| 6.1 — Tool use works without any flag | Unit 8 — Automatic Enablement | FR1.1, FR1.4 | #86 |
+| 6.2 — Graceful degradation for models that reject tool use | Unit 8 — Automatic Enablement | FR1.2-FR1.3 | #86 |
+
+## Coverage Check
+- **Total stories**: 8
+- **Stories assigned**: 8
+- **Unassigned stories**: 0
+- **Units with no stories**: 0
+
+Cross-cutting NFRs (NFR3 revised backward compatibility, NFR4 TDD/coverage, NFR5 prompt usability) apply to all 8 stories/3 units and are re-verified per-unit during Build and Test.

--- a/aidlc-docs/inception/application-design/unit-of-work.md
+++ b/aidlc-docs/inception/application-design/unit-of-work.md
@@ -34,3 +34,33 @@ chat-cli is a monolith — these 5 units are logical modules within the single `
 
 ## Code Organization Note (Brownfield)
 No new top-level directory structure beyond the one new `tools/` package introduced in Unit 2 (see `application-design/components.md`). All other changes extend existing files in `cmd/`, `config/`, and `utils/` in place, per the "Application Code: Workspace root" rule in `aidlc-state.md`.
+
+---
+
+# Initiative 3 Units (#86)
+
+3 units this time (vs. Initiative 2's single implicit unit) — see `builtin-tools-execution-plan.md` for why Units Generation executes here: multiple packages, new persisted state, and a natural dependency seam (the permission engine must exist before the destructive tools can use it).
+
+## Unit 6 — Confirmation and Sticky Approval Engine
+- **Scope**: FR5.1-FR5.4, FR6.1-FR6.3, FR7.1-FR7.2, Stories 8.1-8.3, issue #86
+- **Files touched**: `tools/tool.go` (interface extended), new `tools/permission.go` (`PermissionGate`, `Decision`), new `tools/approvalstore.go` (`ApprovalStore`), new `cmd/permissionprompt.go` (`InteractivePermissionGate`), `tools/registry.go` (`Dispatch` signature extended), `utils/utils.go` (new exported `FindGitBoundary`), `cmd/projectcontext.go` (refactored to call it instead of its private copy)
+- **New components**: `tools.PermissionGate`, `tools.ApprovalStore`, `cmd.InteractivePermissionGate`, `utils.FindGitBoundary`
+- **Definition of done**: A destructive tool call blocks for a once/session/always/deny decision; session approvals are forgotten when `chat` exits; always approvals persist and are scoped per git repository (verified: an approval in one repo doesn't apply in another); a denied call returns a clear `ToolResultBlock` error, not a crash
+- **No dependency** on Units 7/8 - this is the foundational unit
+
+## Unit 7 — New Built-in Tools
+- **Scope**: FR2.1-FR2.3, FR3.1-FR3.2, FR4.1-FR4.3, Stories 7.1-7.3, issue #86
+- **Files touched**: new `tools/writefile.go`, `tools/runshell.go`, `tools/gitdiff.go`
+- **New components**: `tools.WriteFileTool`, `tools.RunShellTool`, `tools.GitDiffTool`
+- **Definition of done**: all 3 tools implement the extended `Tool` interface correctly (`write_file`/`run_shell` declare `RequiresConfirmation() == true` with correct summaries/pattern keys; `git_diff` declares `false`); `write_file` stays cwd-confined; `run_shell` respects its timeout/output cap; `git_diff` handles the non-repo case cleanly
+- **Depends on**: Unit 6 (the extended `Tool` interface and `PermissionGate` must exist before these tools can implement/use them)
+
+## Unit 8 — Automatic Tool-Use Enablement
+- **Scope**: FR1.1-FR1.4, Stories 6.1-6.2, issue #86
+- **Files touched**: `cmd/chat.go` (registry/gate construction, `--tools` removed, retry-without-tools wrapper), `cmd/root.go` (`--tools` flag registration removed)
+- **New components**: None - wiring changes to existing orchestration, plus a retry wrapper structurally identical to `cmd/promptcache.go`'s existing pattern
+- **Definition of done**: no `--tools` flag exists; every `chat` request always attaches a `ToolConfiguration`; a model/request that rejects it triggers exactly one retry without it, with a visible notice; `chat --help` no longer lists `--tools`
+- **Depends on**: Units 6+7 conceptually complete first (so the registry being "always built" has the full 4-tool set and working gate to attach), though technically buildable independently — sequenced last for a coherent incremental build
+
+## Recommended Build Order
+Unit 6 → Unit 7 → Unit 8 (foundation → consumers → the final flip-the-switch wiring change)

--- a/aidlc-docs/inception/plans/builtin-tools-execution-plan.md
+++ b/aidlc-docs/inception/plans/builtin-tools-execution-plan.md
@@ -1,0 +1,101 @@
+# Execution Plan: Built-in Agent Tools (#86)
+
+## Detailed Analysis Summary
+
+### Transformation Scope (Brownfield)
+- **Transformation Type**: Multi-component addition - extends the existing `tools/` subsystem (Initiative 1 Unit 2: `Tool` interface, `Registry`, `Dispatch`) with 3 new tools, and introduces a genuinely new subsystem (a confirmation/permission engine) that nothing in the codebase resembles today.
+- **Primary Changes**: `cmd/chat.go`'s tool-enablement wiring (remove `--tools` flag, always build `ToolConfiguration`, add retry-without-tools-on-rejection mirroring #83); 3 new `tools.Tool` implementations (`write_file`, `run_shell`, `git_diff`); a new permission-engine component (interactive confirmation prompt, pattern matching for `run_shell`/`write_file`, session-scoped in-memory store, per-repository persisted store).
+- **Related Components**: `tools/` package (new tool implementations + the permission engine, likely its own file or sub-package), `cmd/chat.go` (wiring + retry logic), `cmd/root.go` (`--tools` flag removed), `utils.ValidateLocalPath` (reused by `write_file`), the `.git`-boundary-detection concept from #88 (reused for per-repo persisted-approval scoping).
+
+### Change Impact Assessment
+- **User-facing changes**: Yes, significant - `--tools` disappears entirely (tool use becomes unconditional), 3 new capabilities appear, and a new interactive confirmation prompt appears the first time a destructive tool is used in a session. This is the most user-visible change of any initiative so far.
+- **Structural changes**: Yes - the permission engine is new architecture (component design, not just a pure-function file like Initiatives 1-2).
+- **Data model changes**: Yes - a new persisted store for "always" approvals (scoped per git repository) is a new, structured piece of state distinct from the existing flat `config set` key-value system.
+- **API changes**: No new Bedrock API surface - reuses the existing `ToolConfiguration`/`ToolResultBlock` plumbing from Unit 2 entirely as-is.
+- **NFR impact**: Yes, substantial - Security is now a first-class concern (arbitrary shell execution, filesystem writes), not a light NFR pass like Initiative 2's.
+
+### Component Relationships (Brownfield)
+- **Primary Components**: New permission-engine logic (likely `tools/permission.go` or similar - exact package boundary decided in Application Design), 3 new `tools.Tool` implementations
+- **Consuming Component**: `cmd/chat.go` - registers the new tools, calls the permission engine before dispatching destructive ones, implements the retry-without-tools fallback
+- **Shared Components Reused As-Is**: `tools.Registry`/`Tool` interface/`Dispatch` (Unit 2), `utils.ValidateLocalPath` (Units 2/4), the `.git`-boundary-walk concept (Initiative 2, `cmd/projectcontext.go`'s `findGitBoundary`-equivalent logic)
+- **Dependent Components**: `write_file`/`run_shell` depend on the permission engine existing before they can execute destructively; `git_diff` has no such dependency (read-only)
+- **Supporting Components**: None (no infra in this project)
+
+### Risk Assessment
+- **Risk Level**: Medium-High - `run_shell` is arbitrary command execution and `write_file` is a destructive filesystem action; the confirmation gate is the primary control, so its correctness matters more than anything in Initiatives 1-2. Mitigated by: no static command allowlist needed (gate covers it), cwd-confinement reused from proven code, and denial/auto-disable paths made explicit as their own user stories.
+- **Rollback Complexity**: Moderate - removing `--tools` is a behavior change existing scripts/muscle-memory may depend on (though the flag simply becomes a no-op/absent rather than breaking anything that doesn't reference it).
+- **Testing Complexity**: Moderate-Complex - the permission engine's pattern-matching and storage logic is pure and directly unit-testable (similar to #88's `t.TempDir()` approach for the persisted store), but the interactive confirmation prompt itself needs either an injectable prompt function (mirroring how `runChatTurnWithTools`'s `converseStreamFunc` was made injectable in Unit 2) or a documented manual-verification gap, decided in Functional Design.
+
+## Workflow Visualization
+
+```mermaid
+flowchart TD
+    Start(["User Request: Built-in Agent Tools #86"])
+
+    subgraph INCEPTION["🔵 INCEPTION PHASE"]
+        WD["Workspace Detection<br/><b>COMPLETED</b>"]
+        RA["Requirements Analysis<br/><b>COMPLETED</b>"]
+        US["User Stories<br/><b>COMPLETED</b>"]
+        WP["Workflow Planning<br/><b>COMPLETED</b>"]
+        AD["Application Design<br/><b>EXECUTE</b>"]
+        UG["Units Generation<br/><b>EXECUTE</b>"]
+    end
+
+    subgraph CONSTRUCTION["🟢 CONSTRUCTION PHASE"]
+        FD["Per-Unit Functional Design + NFR<br/><b>EXECUTE</b>"]
+        ID["Infrastructure Design<br/><b>SKIP</b>"]
+        CG["Code Generation<br/><b>EXECUTE</b>"]
+        BT["Build and Test<br/><b>EXECUTE</b>"]
+    end
+
+    subgraph OPERATIONS["🟡 OPERATIONS PHASE"]
+        OPS["Operations<br/><b>PLACEHOLDER</b>"]
+    end
+
+    Start --> WD --> RA --> US --> WP --> AD --> UG --> FD --> ID --> CG --> BT --> OPS --> End(["Complete"])
+
+    style WD fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style RA fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style US fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style WP fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style AD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style UG fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style FD fill:#FFA726,stroke:#E65100,stroke-width:3px,stroke-dasharray: 5 5,color:#000
+    style ID fill:#BDBDBD,stroke:#424242,stroke-width:2px,stroke-dasharray: 5 5,color:#000
+    style CG fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style BT fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style OPS fill:#FFF59D,stroke:#F9A825,stroke-width:2px,color:#000
+    style Start fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+    style End fill:#CE93D8,stroke:#6A1B9A,stroke-width:3px,color:#000
+
+    linkStyle default stroke:#333,stroke-width:2px
+```
+
+## Phases to Execute
+
+### 🔵 INCEPTION PHASE
+- [x] Workspace Detection, Requirements Analysis, User Stories, Workflow Planning (this document) - COMPLETED
+- [ ] Application Design - **EXECUTE**
+  - **Rationale**: The permission engine is genuinely new architecture (component boundaries, storage shape, how tools call into the gate) - unlike Initiatives 1-2, this isn't just a pure-function file following an established pattern. Needs explicit component/interface design before splitting into units.
+- [ ] Units Generation - **EXECUTE**
+  - **Rationale**: Multiple packages affected, new persisted state, complex pattern-matching logic, and natural seams between (a) automatic-enablement wiring, (b) the permission engine itself, and (c) the 3 new tools that consume it - matches Units Generation's "new data models/complex algorithms/multiple packages" execute criteria, unlike Initiative 2's single natural unit.
+
+### 🟢 CONSTRUCTION PHASE
+- [ ] Per-Unit Functional Design + NFR - **EXECUTE** (per unit, finalized after Units Generation)
+  - **Rationale**: Security is now a first-class NFR category (arbitrary command execution, destructive writes) - every unit touching the permission engine or the destructive tools needs explicit NFR treatment, not a skip.
+  - Infrastructure Design sub-step - **SKIP**: No infrastructure in this project (unchanged from Initiatives 1-2).
+- [ ] Code Generation - **EXECUTE (ALWAYS)**
+- [ ] Build and Test - **EXECUTE (ALWAYS)**
+
+### 🟡 OPERATIONS PHASE
+- [ ] Operations - **PLACEHOLDER** (unchanged)
+
+## Estimated Timeline
+- **Total Stages Executing**: 6 of 7 possible Inception/Construction stages (only Infrastructure Design skipped) - the most complete treatment of any initiative so far, proportional to the risk profile.
+- **Estimated Duration**: Comparable to Initiative 1's Unit 2 (Tool Use) in complexity, likely the largest single initiative to date given the new permission-engine subsystem.
+
+## Success Criteria
+- **Primary Goal**: `chat` gains 3 new tools and automatic tool-use enablement, with a confirmation/sticky-approval system that makes destructive actions safe by construction, not by convention.
+- **Key Deliverables**: New tools, permission engine (pattern matching, session store, per-repo persisted store, confirmation prompt), removal of `--tools`, retry-without-tools graceful degradation, full test coverage, updated docs.
+- **Quality Gates**: `make test`, `make lint`, `make test-coverage` (no regression), `go test -tags=integration -v .` all passing; the denial and auto-disable-on-rejection paths specifically exercised, not just the happy path.
+- **Integration Testing**: Cross-unit composition scenario confirming a destructive tool call actually blocks on the confirmation gate before executing, and that a granted "always" approval in one repo doesn't leak into another.

--- a/aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
+++ b/aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
@@ -8,7 +8,7 @@
 - **Granularity**: The approval-tier scenarios (once/session/always/deny/auto-disable) are broken into their own stories rather than folded as acceptance-criteria bullets under one giant "confirmation" story, given the User Stories Assessment's specific reasoning for executing this stage at all (making each branch of that decision tree independently testable).
 
 ## Steps
-- [ ] Extend `aidlc-docs/inception/user-stories/personas.md` with this initiative's goals/pain-points (same file, additive - not a new persona)
-- [ ] Generate `aidlc-docs/inception/user-stories/stories.md` additions: Epic 6 (Automatic Tool-Use Enablement, FR1), Epic 7 (write_file/run_shell/git_diff, FR2-4), Epic 8 (Confirmation and Sticky Approval, FR5-7)
-- [ ] Verify every FR (FR1.1-FR7.2) is traceable to at least one story's acceptance criteria
-- [ ] Verify each story is independently testable per INVEST
+- [x] Extend `aidlc-docs/inception/user-stories/personas.md` with this initiative's goals/pain-points (same file, additive - not a new persona)
+- [x] Generate `aidlc-docs/inception/user-stories/stories.md` additions: Epic 6 (Automatic Tool-Use Enablement, FR1), Epic 7 (write_file/run_shell/git_diff, FR2-4), Epic 8 (Confirmation and Sticky Approval, FR5-7)
+- [x] Verify every FR (FR1.1-FR7.2) is traceable to at least one story's acceptance criteria
+- [x] Verify each story is independently testable per INVEST

--- a/aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
+++ b/aidlc-docs/inception/plans/builtin-tools-story-generation-plan.md
@@ -1,0 +1,14 @@
+# Story Generation Plan: Built-in Agent Tools (#86)
+
+## Methodology Decisions (stated as assumptions, consistent with Initiative 1's calibration - not reopening a second Q&A round given how much was already resolved in Requirements Analysis)
+
+- **Persona**: Reuse the single existing "chat-cli User" persona from Initiative 1/2 (`aidlc-docs/inception/user-stories/personas.md`), extended with this initiative's specific goals/pain-points rather than creating a new persona file - this remains a single-user-type terminal tool (per the standing assessment already made twice).
+- **Breakdown approach**: Feature-based, one epic per FR group from `builtin-tools-requirements.md` (FR1 automatic enablement, FR2-4 the three tools, FR5-7 the confirmation/approval system) - same approach as Initiative 1's `stories.md`.
+- **Story format**: `As <persona>, I want <capability>, so that <benefit>` with Given/When/Then acceptance criteria tagged back to specific FR numbers, plus an INVEST note per story - identical format to the existing `stories.md`.
+- **Granularity**: The approval-tier scenarios (once/session/always/deny/auto-disable) are broken into their own stories rather than folded as acceptance-criteria bullets under one giant "confirmation" story, given the User Stories Assessment's specific reasoning for executing this stage at all (making each branch of that decision tree independently testable).
+
+## Steps
+- [ ] Extend `aidlc-docs/inception/user-stories/personas.md` with this initiative's goals/pain-points (same file, additive - not a new persona)
+- [ ] Generate `aidlc-docs/inception/user-stories/stories.md` additions: Epic 6 (Automatic Tool-Use Enablement, FR1), Epic 7 (write_file/run_shell/git_diff, FR2-4), Epic 8 (Confirmation and Sticky Approval, FR5-7)
+- [ ] Verify every FR (FR1.1-FR7.2) is traceable to at least one story's acceptance criteria
+- [ ] Verify each story is independently testable per INVEST

--- a/aidlc-docs/inception/plans/builtin-tools-user-stories-assessment.md
+++ b/aidlc-docs/inception/plans/builtin-tools-user-stories-assessment.md
@@ -1,0 +1,24 @@
+# User Stories Assessment: Built-in Agent Tools (#86)
+
+## Request Analysis
+- **Original Request**: Add `write_file`/`run_shell`/`git_diff` tools, plus (per the user's clarifying answers) replace the `--tools` opt-in flag with automatic enablement and a new destructive-action confirmation system with three-tier (once/session/always) pattern-based sticky approval.
+- **User Impact**: Direct - this changes `chat`'s default behavior (tools now always attempted) and introduces an entirely new interaction pattern (confirmation prompts with a persistent choice) that users will encounter on essentially every session that uses a destructive tool.
+- **Complexity Level**: Complex - new subsystem (permission engine), multiple new interaction flows, a revision to previously-established default behavior.
+- **Stakeholders**: Single persona (the chat-cli User, per Initiative 1/2's established assessment - this remains a single-user-type terminal tool).
+
+## Assessment Criteria Met
+- [x] **High Priority**: New User Features (3 new tools) - any new functionality users directly interact with
+- [x] **High Priority**: User Experience Changes - the automatic-tool-use + confirmation-gate change modifies the existing `chat` workflow non-trivially (Unit 2's `--tools` flag is being removed)
+- [x] **Medium Priority**: Security Enhancements - the confirmation/approval system is functionally a permissions feature
+- [x] **Complexity Factor**: Ambiguity - the three-tier approval UX (once/session/always) has several distinct scenarios (first destructive call, a repeat call matching a session approval, a repeat call matching a persisted approval, a denial, an auto-disable-on-model-rejection) that benefit from being made explicit and testable
+- [x] **Complexity Factor**: Risk - destructive actions (file writes, arbitrary shell execution) carry real consequences if the approval/confirmation logic has a gap
+
+## Decision
+**Execute User Stories**: Yes
+
+**Reasoning**: This is a meaningfully different case from Initiative 2 (a single, simple, automatic discovery mechanism with no new subsystem). Here, the number of distinct interaction scenarios (5+, listed above) each need a clear "given/when/then" so that: (a) implementation has an unambiguous spec for each approval-tier branch, (b) Build and Test has concrete scenarios to verify against, and (c) the security-sensitive paths (deny, auto-disable-on-rejection) are explicitly called out rather than left implicit in FR prose alone.
+
+## Expected Outcomes
+- Explicit acceptance criteria for every branch of the confirmation/approval decision tree, directly reusable as test-case scaffolding during Code Generation (same role stories played in Initiative 1).
+- A clear separation between "read-only tool, no gate" stories and "destructive tool, full gate" stories, reducing the risk of the gate being accidentally applied inconsistently.
+- Explicit coverage of the two "unhappy path" flows that most need to be right: a denied action, and the automatic tools-disabled-on-rejection degradation.

--- a/aidlc-docs/inception/requirements/builtin-tools-clarification-questions.md
+++ b/aidlc-docs/inception/requirements/builtin-tools-clarification-questions.md
@@ -1,0 +1,55 @@
+# Built-in Agent Tools (#86) - Clarification Questions
+
+## What I heard from your answer
+
+1. **No more `--tools` flag friction** — tool use should "just work." I'm reading this as: `chat` enables tool use automatically, no opt-in flag needed. Since Bedrock has no "does this model support tool use" capability check, I'd handle the risk the same way prompt caching (#83) already does — attempt it, and if a model/request rejects the `ToolConfiguration` field, silently retry once without it. This is a real change to Initiative 1's Unit 2 design (where `--tools` was deliberately opt-in specifically to avoid this risk) — confirming before I treat it as settled, since it revises a previous explicit decision rather than just adding to it.
+
+2. **Every tool call requires confirmation**, with a session-level "sticky" option so you're not re-prompted for the same thing repeatedly.
+
+3. **Pattern-based scoping for the "sticky" choice** — like Claude Code's own permission model (e.g. approving `git diff:*` covers any `git diff` invocation, not just one exact command). At the prompt, you'd choose whether to approve just this one call, or a broader pattern going forward.
+
+This is a good, coherent design and it mirrors how Claude Code itself handles exactly this problem (fitting, since this session runs inside Claude Code). Before I write it into requirements.md, four things need pinning down:
+
+## Question 1
+Today's one existing tool, `read_file`, runs silently with no confirmation (Initiative 1 design). Should the new confirmation gate apply to **every** tool call uniformly (including `read_file` and the new read-only `git_diff`), or only to the destructive ones (`write_file`, `run_shell`)?
+
+A) Every tool, uniformly - simpler mental model, no special-casing "safe" vs "risky" in the gate logic itself
+
+B) Only `write_file`/`run_shell` - `read_file`/`git_diff` stay silent since they're read-only and this preserves `read_file`'s existing behavior exactly
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 2
+What should the pattern granularity actually be for each tool, when you choose "allow going forward" rather than "just this once"?
+
+A) `run_shell`: pattern matches on the **base command** (e.g. approving `git diff main` offers to approve all `git *` calls). `write_file`: pattern matches on **directory** (e.g. approving a write to `src/foo.go` offers to approve all writes under `src/*`).
+
+B) `run_shell`: pattern matches on the **full command prefix** you can edit at the prompt (e.g. approve `git diff*` specifically, not all of `git`). `write_file`: pattern matches on a **glob you can edit** at the prompt (e.g. `src/**/*.go`).
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 3
+Should approved patterns persist across `chat` sessions (saved to config, so you're not re-approving `git *` every time you start a new session), or are they always session-only (reset every time `chat` starts, matching how a fresh terminal session normally works)?
+
+A) Session-only - resets every time `chat` starts (simpler, safer default, no new persisted state to manage)
+
+B) Persisted - saved to the config file so approvals carry over between sessions
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 4
+Since `--tools` goes away as something you have to remember to pass, should there still be a flag to **disable** tool use entirely for someone who doesn't want it (mirroring `--no-context-file` from #88), or is tool use simply always-on with no opt-out?
+
+A) Add `--no-tools` as the opt-out, mirroring `--no-context-file`'s precedent
+
+B) Always-on, no opt-out flag in this pass
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 

--- a/aidlc-docs/inception/requirements/builtin-tools-clarification-questions.md
+++ b/aidlc-docs/inception/requirements/builtin-tools-clarification-questions.md
@@ -19,7 +19,7 @@ B) Only `write_file`/`run_shell` - `read_file`/`git_diff` stay silent since they
 
 C) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: B (destructive only - write_file/run_shell; read_file/git_diff stay silent)
 
 ## Question 2
 What should the pattern granularity actually be for each tool, when you choose "allow going forward" rather than "just this once"?
@@ -30,7 +30,7 @@ B) `run_shell`: pattern matches on the **full command prefix** you can edit at t
 
 C) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: A (coarse: base command for run_shell, directory for write_file)
 
 ## Question 3
 Should approved patterns persist across `chat` sessions (saved to config, so you're not re-approving `git *` every time you start a new session), or are they always session-only (reset every time `chat` starts, matching how a fresh terminal session normally works)?
@@ -41,7 +41,7 @@ B) Persisted - saved to the config file so approvals carry over between sessions
 
 C) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: Neither strictly A nor B as originally framed - user wants a 3-way choice offered at prompt time: once / this session / always (persisted). Recording as a new decision, not a pre-listed letter.
 
 ## Question 4
 Since `--tools` goes away as something you have to remember to pass, should there still be a flag to **disable** tool use entirely for someone who doesn't want it (mirroring `--no-context-file` from #88), or is tool use simply always-on with no opt-out?
@@ -52,4 +52,4 @@ B) Always-on, no opt-out flag in this pass
 
 C) Other (please describe after [Answer]: tag below)
 
-[Answer]: 
+[Answer]: Neither A nor B as originally framed - no --no-tools flag; instead, a model/request that rejects the tool-use field is detected and tools are automatically disabled for the rest of that request (same retry-without-tools pattern as prompt caching's retry-without-cache), with a visible notice to the user.

--- a/aidlc-docs/inception/requirements/builtin-tools-questions.md
+++ b/aidlc-docs/inception/requirements/builtin-tools-questions.md
@@ -1,0 +1,84 @@
+# Requirements Clarification Questions - Built-in Agent Tools (#86)
+
+This feature has real safety implications (`write_file` is destructive, `run_shell` is arbitrary command execution), so more of this needs your input up front than Initiative 2 did.
+
+## Question 1
+Issue #86 names three tools: `write_file`, `run_shell`, `git_diff`. Should this pass build all three together, or stage them?
+
+A) All three together - they're a natural set and share the same confirmation-flow design work
+
+B) `write_file` and `git_diff` only this pass - defer `run_shell` (the highest-risk one) to a follow-up issue once the confirmation UX is proven out
+
+C) `git_diff` only this pass (read-only, no confirmation-flow design needed at all) - defer both destructive tools
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+
+## Question 2
+Today, `--tools` unconditionally exposes the one existing built-in tool (`read_file`, read-only, cwd-confined). Should `write_file`/`run_shell` be available under that same `--tools` flag, or gated separately?
+
+A) Same `--tools` flag - once you opt into tool use at all, all built-in tools (including destructive ones) are available, gated instead by a per-call confirmation prompt
+
+B) A separate opt-in is required for destructive tools (e.g. `--dangerous-tools` or similar) on top of `--tools` - so someone can enable read-only tool use without exposing write/exec at all
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 3
+What should the confirmation prompt look like for a destructive tool call (`write_file`, `run_shell`)?
+
+A) Show exactly what will happen (the file path + new content diff for `write_file`; the exact command string for `run_shell`), then a `y/n` prompt that blocks the conversation until answered
+
+B) Same as A, but also offer a session-level "always allow" choice (e.g. `y`/`n`/`a`) so the user isn't re-prompted for every subsequent destructive call in the same session
+
+C) No interactive prompt in this pass - require an explicit `--auto-approve-tools` (or similar) flag at startup instead, and refuse all destructive calls without it
+
+D) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 4
+Should there be a non-interactive escape hatch (a flag to skip confirmation prompts entirely, for scripting/automation use), given `chat` is normally interactive?
+
+A) Yes - an explicit flag (e.g. `--yolo` or `--auto-approve`) that skips all confirmation prompts, off by default
+
+B) No - confirmation is always required in this pass; a bypass flag can be a follow-up if there's demand
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 5
+Scope for `write_file` - should it reuse the exact same cwd-confinement rule as `read_file` (`utils.ValidateLocalPath`), and can it create new files or only overwrite existing ones?
+
+A) Same cwd confinement as `read_file`; can both create new files and overwrite existing ones (within cwd)
+
+B) Same cwd confinement, but overwrite-only - creating brand-new files is out of scope for this pass
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 6
+Scope for `run_shell` - how should the command actually run?
+
+A) Run via the shell (e.g. `sh -c "<command>"`) with the working directory fixed to `chat-cli`'s own cwd (same confinement spirit as the file tools), a fixed timeout, and combined stdout+stderr (truncated past some size) returned to the model - no allowlist/denylist of specific commands
+
+B) Same as A, but with an explicit command allowlist (e.g. only `git`, `ls`, `cat`, a small fixed set) rather than allowing arbitrary commands
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+
+## Question 7
+Scope for `git_diff` - what exactly should it run, and does it need arguments?
+
+A) Runs `git diff` with no arguments in `chat-cli`'s cwd, returns the raw output - if cwd isn't a git repo, returns a clear (non-fatal) error to the model
+
+B) Same as A, but accepts an optional argument (e.g. a path or ref) the model can pass, mirroring `git diff <path>`/`git diff <ref>`
+
+C) Other (please describe after [Answer]: tag below)
+
+[Answer]: 

--- a/aidlc-docs/inception/requirements/builtin-tools-requirements.md
+++ b/aidlc-docs/inception/requirements/builtin-tools-requirements.md
@@ -1,0 +1,83 @@
+# Requirements: Built-in Agent Tools (#86)
+
+## Intent Analysis Summary
+
+- **User Request**: Following Initiative 2 (#88), user picked #86 next: "Once tool use is supported, add a small first-party toolset — read file, write file, run a shell command, git diff — so chat-cli chat can act as a lightweight, Bedrock-native coding assistant directly in the terminal... Needs careful scoping around confirmation prompts before destructive actions." Through two rounds of clarifying questions, the user pushed the scope further than the issue's original text: tool use should become automatic (no `--tools` flag to remember), gated instead by a per-call confirmation system for destructive actions, with pattern-based "sticky" approval modeled on how permission prompts work in coding-agent tools generally.
+- **Request Type**: New Feature, with a revision to an existing feature (Initiative 1 Unit 2's `--tools` opt-in flag is being replaced by automatic enablement + graceful degradation)
+- **Scope Estimate**: Multiple Components — extends the existing `tools/` package (2 new tools), introduces a genuinely new subsystem (the confirmation/permission-pattern engine) that nothing in the codebase resembles today, and changes `cmd/chat.go`'s tool-enablement wiring from Unit 2
+- **Complexity Estimate**: Complex — the permission-pattern engine (three-tier once/session/always approval, coarse pattern matching, per-repo persisted storage) is new architecture, not a simple flag/config addition like Initiatives 1-2
+- **Related GitHub Issue**: [#86](https://github.com/chat-cli/chat-cli/issues/86)
+- **Depth**: Comprehensive — real security-relevant design (arbitrary shell execution, filesystem writes), multiple new interaction flows, and a new persisted-state concept. Given this, User Stories and Application Design are likely warranted (final call in Workflow Planning) rather than skipped as they were in Initiative 2.
+
+## Clarifying Questions and Answers
+
+Two rounds - see `aidlc-docs/inception/requirements/builtin-tools-questions.md` and `builtin-tools-clarification-questions.md` for the full record. Summary of decisions:
+
+1. **Tool scope**: build `write_file`, `run_shell`, and `git_diff` together in this pass (alongside the existing `read_file` from Unit 2).
+2. **Tool-use enablement**: automatic, no `--tools` flag. `chat` always builds and sends a `ToolConfiguration`. If a model/request rejects it, `chat` automatically retries once without tools (mirroring #83's cache-point retry pattern) and tells the user tools were turned off for that session - no `--no-tools` opt-out flag needed, since the automatic-disable-on-rejection already covers "a model that can't/shouldn't use tools."
+3. **Confirmation gate scope**: only for destructive tools (`write_file`, `run_shell`). The existing `read_file` and the new `git_diff` remain silent/no-confirmation, since they're read-only - consistent with `read_file`'s existing Unit 2 behavior.
+4. **Confirmation UX**: a blocking prompt before every destructive call, showing exactly what will happen (the command string for `run_shell`; the path + content for `write_file`), with a three-way choice: **approve once**, **approve for the rest of this session**, or **approve always** (persisted).
+5. **Pattern granularity** (for "session"/"always" approval): coarse. `run_shell` patterns match on the **base command** (e.g. approving one `git diff` call offers to approve all `git *` calls for the chosen scope). `write_file` patterns match on **directory** (e.g. approving a write to `src/foo.go` offers to approve all writes under `src/*`).
+6. **Persistence for "always"**: persisted approvals are scoped **per-repository** (see Assumption 4 below for the exact mechanism), not global across every project - approving `git *` in one repo shouldn't silently apply in an unrelated one.
+
+## Assumptions Made (flag in "Request Changes" if any are wrong)
+
+1. **`write_file`** reuses `utils.ValidateLocalPath` (the same cwd-confinement already used by `read_file` and `--document`) and can both create new files and overwrite existing ones within that confinement.
+2. **`run_shell`** executes via the shell (`sh -c "<command>"`), working directory fixed to `chat-cli`'s own cwd, with a fixed timeout (proposed: 30s) and combined stdout+stderr truncated past a size cap (proposed: 32KB, matching #88's precedent) returned to the model. No command allowlist/denylist - the confirmation gate is the control, not a static list.
+3. **`git_diff`** accepts an optional argument (path or ref) mirroring `git diff <arg>`; with no argument, runs a plain `git diff`. If cwd isn't inside a git repository, it returns a clear error *to the model* (a `ToolResultBlock` error, not a fatal CLI error) - consistent with Unit 2's fail-closed dispatch pattern.
+4. **Persisted-approval storage**: a new store, scoped by git repository root (reusing #88's `.git`-boundary-detection concept - the same directory `resolveContextFilenames`'s boundary walk would find), separate from the existing flat `config set`/`unset` key-value system (which isn't shaped for structured, per-repo, per-pattern data). Exact file format/location is a Functional Design decision, not fixed here.
+5. **Session-scoped approvals** (the "this session" tier) live in memory only, tied to the running `chat` process, and are gone once it exits - no file I/O involved for that tier.
+6. **The existing `--tools` flag is removed** (not deprecated-but-kept) since automatic enablement supersedes it entirely, and Initiative 1 established a precedent of not carrying forward flags that no longer do anything meaningful.
+7. **Backward compatibility scope**: this initiative *intentionally* changes default `chat` behavior (tools are now always attempted) - this is a deliberate, user-directed revision of Initiative 1's NFR1, not a violation of it. Everything else (no confirmation for read-only tools, graceful degradation for non-tool models) is designed to keep the change low-friction.
+8. **`prompt` is unaffected** - this entire initiative, like Initiative 2, is `chat`-only. Tool use has never been wired into `prompt`.
+
+## Functional Requirements
+
+### FR1 - Automatic Tool-Use Enablement
+- FR1.1: `chat` always builds a non-empty `ToolConfiguration` (via the existing `tools.Registry` from Unit 2, now populated with 4 tools) and attaches it to every request - no flag required.
+- FR1.2: If a request is rejected because the model/request doesn't support tool use, `chat` retries once without the `ToolConfiguration`, mirroring #83's existing cache-point retry pattern exactly (detect failure, strip the field, retry, surface normally if that also fails).
+- FR1.3: When the automatic retry-without-tools happens, the user sees a clear, one-line notice that tools were disabled for this session (not a silent degradation).
+- FR1.4: The `--tools` flag is removed from `cmd/root.go`.
+
+### FR2 - `write_file` Tool
+- FR2.1: New tool, `write_file`, taking a path and content, confined to the working directory via `utils.ValidateLocalPath`.
+- FR2.2: Can create a new file or overwrite an existing one.
+- FR2.3: Requires confirmation (FR5) before executing - never writes without an approved gate.
+
+### FR3 - `run_shell` Tool
+- FR3.1: New tool, `run_shell`, taking a command string, executed via the shell in `chat-cli`'s cwd, with a fixed timeout and truncated combined stdout+stderr returned to the model.
+- FR3.2: Requires confirmation (FR5) before executing.
+
+### FR4 - `git_diff` Tool
+- FR4.1: New tool, `git_diff`, taking an optional path/ref argument, running `git diff [arg]` in cwd.
+- FR4.2: Read-only - does not require confirmation (FR5 doesn't apply).
+- FR4.3: A cwd outside any git repository produces a clear `ToolResultBlock` error back to the model, not a fatal CLI error.
+
+### FR5 - Confirmation Gate (Destructive Tools Only)
+- FR5.1: Before `write_file` or `run_shell` executes, the CLI shows the user exactly what will happen (file path + content for `write_file`; the exact command string for `run_shell`) and blocks for a decision.
+- FR5.2: The user chooses one of: approve **once**, approve for the rest of **this session**, approve **always** (persisted), or **deny**.
+- FR5.3: A denied call is reported back to the model as a `ToolResultBlock` error (e.g. "user declined this action"), not a fatal error - the conversation continues.
+- FR5.4: `read_file` and `git_diff` never trigger this gate (FR2.3/FR3.2 vs. FR4.2).
+
+### FR6 - Pattern-Based Sticky Approval
+- FR6.1: For `run_shell`, a "session"/"always" approval is scoped to the **base command** (the first whitespace-separated token, e.g. `git`, `npm`) - approving one call offers to approve that base command generally, not just the exact string.
+- FR6.2: For `write_file`, a "session"/"always" approval is scoped to the **containing directory** - approving one write offers to approve further writes anywhere under that directory.
+- FR6.3: Before executing a destructive call, the CLI checks existing session and persisted approvals (FR6.1/FR6.2 patterns) and skips the confirmation gate (FR5) entirely if a match is found.
+
+### FR7 - Persisted ("Always") Approval Storage
+- FR7.1: "Always" approvals are stored per git repository (keyed by the repo root, same boundary-detection concept as #88), so approvals in one project don't apply in another.
+- FR7.2: "Session" approvals are in-memory only and never touch disk.
+
+## Non-Functional Requirements
+
+- **NFR1 - Security**: The confirmation gate (FR5) is the primary control for destructive actions, given there is no static command allowlist for `run_shell` (Assumption 2). `write_file` remains cwd-confined via the existing `utils.ValidateLocalPath` choke point. The persisted-approval store (FR7) must not be world-readable/writable (reuse the existing config file's permission conventions).
+- **NFR2 - Reliability**: FR1.2's automatic retry-without-tools ensures `chat` never hard-fails for a model that rejects tool use - this is the single most important reliability property of this initiative, since tool use is no longer opt-in.
+- **NFR3 - Backward Compatibility (revised)**: This initiative intentionally changes default behavior (Assumption 7) - flagged prominently rather than silently treated as a violation of Initiative 1's original NFR1.
+- **NFR4 - TDD & Coverage**: Per `CLAUDE.md`, tests before implementation. `cmd`/`tools` package coverage must not regress.
+- **NFR5 - Usability**: The confirmation prompt (FR5.1) must show enough information for an informed decision (full command string or file path+content), not a truncated/vague summary.
+
+## Out of Scope (this pass)
+- A static command allowlist/denylist for `run_shell` - the confirmation gate is the control instead.
+- Editable/custom patterns at prompt time (Question 2's option B) - coarse, fixed granularity only (base command / directory).
+- Extending any of this to `prompt` (chat-only, consistent with #88).
+- MCP-sourced tools (#87) - this initiative only covers the 3 new built-in tools plus the existing `read_file`.

--- a/aidlc-docs/inception/user-stories/personas.md
+++ b/aidlc-docs/inception/user-stories/personas.md
@@ -17,3 +17,15 @@ chat-cli is a single-user-type terminal tool — there is one persona. A separat
   - Can't see or use the newer reasoning/extended-thinking capabilities some models now offer.
 - **Technical proficiency**: High — comfortable with CLI flags, config files, and reading error messages; not necessarily a Go developer.
 - **Relationship to GitHub issues**: This persona's needs map directly to issues #81-#85.
+
+## Persona Extension: Initiative 3 (Built-in Agent Tools, #86)
+
+Same persona, same file — no new persona type, extending the existing one with goals/pain points specific to this initiative:
+
+- **Additional goals**:
+  - Let the model take real action in the local project (edit a file, run a command, inspect a diff) without switching to a separate, heavier coding-agent tool.
+  - Trust that destructive actions (writes, shell commands) never happen without an explicit decision, but without being nagged for the same decision repeatedly within — or across — sessions.
+- **Additional pain points this initiative addresses**:
+  - Had to remember and pass `--tools` every session to get any tool behavior at all, even the safe, read-only `read_file` tool from #82.
+  - No way for the model to edit files, run commands, or see a diff — `chat` could only read, never act.
+  - No middle ground between "the model can never do anything destructive" and "every single destructive call needs a fresh yes/no" — no way to say "yes, and stop asking for `git` commands this session."

--- a/aidlc-docs/inception/user-stories/stories.md
+++ b/aidlc-docs/inception/user-stories/stories.md
@@ -88,7 +88,7 @@ Persona: **The chat-cli User** (see `personas.md`). Breakdown: Feature-based, on
 
 ---
 
-## Traceability Summary
+## Traceability Summary (Initiative 1, #81-#85)
 
 | Story | Epic | FR/NFR IDs | Issue |
 |---|---|---|---|
@@ -100,3 +100,115 @@ Persona: **The chat-cli User** (see `personas.md`). Breakdown: Feature-based, on
 | 5.1 | Extended Thinking | FR5.1-FR5.4 | #85 |
 
 NFR1 (backward compatibility), NFR2 (TDD/coverage), NFR4 (error handling), NFR5 (no new deps), NFR6 (docs), NFR7 (streaming compatibility) apply across all 6 stories and are re-asserted per-story implicitly by "behavior unchanged when flag not set" acceptance criteria.
+
+---
+
+# Initiative 3 — Built-in Agent Tools (#86)
+
+FR/NFR IDs below reference `aidlc-docs/inception/requirements/builtin-tools-requirements.md` (a separate numbering space from Initiative 1's FR1-FR5 above - disambiguated here as "Epic 6/7/8" to avoid confusion with Epics 1-5).
+
+## Epic 6 — Automatic Tool-Use Enablement (FR1, [#86](https://github.com/chat-cli/chat-cli/issues/86))
+
+### Story 6.1 — Tool use works without any flag
+**As** the chat-cli User, **I want** `chat` to make tools available to the model automatically, **so that** I don't have to remember and pass `--tools` every session.
+
+**Acceptance Criteria**:
+- Given I start `chat-cli` with no special flags, when a request is sent, then it includes a non-empty `ToolConfiguration` built from the registry (now `read_file`, `write_file`, `run_shell`, `git_diff`). *(FR1.1)*
+- Given the `--tools` flag from Initiative 1 no longer exists, when I run `chat-cli --help`, then `--tools` is absent from the flag list. *(FR1.4)*
+
+**INVEST**: Small, independent - pure wiring change, testable by asserting the request always carries a `ToolConfiguration`.
+
+### Story 6.2 — Graceful degradation for models that reject tool use
+**As** the chat-cli User, **I want** `chat` to keep working even on a model that doesn't support tool use, **so that** the automatic-enablement change (Story 6.1) never breaks a session outright.
+
+**Acceptance Criteria**:
+- Given a model/request rejects the `ToolConfiguration` field, when that failure occurs, then chat-cli automatically retries the same request once without it, mirroring the existing cache-point retry pattern from #83. *(FR1.2)*
+- Given the retry-without-tools succeeds, when the response streams back to me, then I see a clear, one-line notice that tools were disabled for this session (not a silent change in behavior). *(FR1.3)*
+- Given tools were disabled this way, when I continue the conversation, then no further requests in that session re-attempt the `ToolConfiguration` (no repeated failed round-trips). *(FR1.2, FR1.3)*
+
+**INVEST**: Independent of Story 6.1's happy path but depends on it existing; testable with a mocked Converse call that rejects the tool field on the first attempt and succeeds on retry.
+
+---
+
+## Epic 7 — New Built-in Tools (FR2-FR4, [#86](https://github.com/chat-cli/chat-cli/issues/86))
+
+### Story 7.1 — Model edits a local file
+**As** the chat-cli User, **I want** the model to be able to create or overwrite a file in my project when I've approved it, **so that** it can act like a lightweight coding assistant instead of only describing what I should change myself.
+
+**Acceptance Criteria**:
+- Given the model requests `write_file` with a path and content, when the path resolves within the working directory (via `utils.ValidateLocalPath`), then, after approval (Epic 8), the file is created or overwritten with that content. *(FR2.1, FR2.2)*
+- Given the model requests a path outside the working directory, when chat-cli validates it, then it refuses and returns an error result to the model, the same as `read_file`'s existing traversal protection. *(FR2.1, NFR1)*
+- Given a `write_file` call has not yet been approved, when chat-cli processes it, then no write happens until the confirmation gate (Epic 8) resolves. *(FR2.3)*
+
+**INVEST**: Small, depends on Epic 8's gate existing but is separately testable (path validation and file-write logic can be tested independently of the approval UI).
+
+### Story 7.2 — Model runs a shell command
+**As** the chat-cli User, **I want** the model to be able to run a shell command when I've approved it, **so that** it can do things like run tests, install a dependency, or check tool versions without me leaving the conversation.
+
+**Acceptance Criteria**:
+- Given the model requests `run_shell` with a command string, when it's approved (Epic 8), then chat-cli executes it via the shell in chat-cli's own working directory and returns combined, size-capped stdout+stderr to the model. *(FR3.1)*
+- Given the command runs longer than the fixed timeout, when that timeout elapses, then chat-cli terminates it and returns a clear timeout result to the model rather than hanging the session. *(FR3.1, NFR2)*
+- Given a `run_shell` call has not yet been approved, when chat-cli processes it, then no command executes until the confirmation gate (Epic 8) resolves. *(FR3.2)*
+
+**INVEST**: Small, mirrors Story 7.1's shape (a destructive tool gated by Epic 8) but independently testable (command execution/timeout/truncation logic vs. approval flow).
+
+### Story 7.3 — Model inspects the working tree diff
+**As** the chat-cli User, **I want** the model to be able to see `git diff` output, **so that** it can reason about my current uncommitted changes without me manually pasting them in.
+
+**Acceptance Criteria**:
+- Given the model requests `git_diff` with no argument, when chat-cli runs it, then it returns the plain `git diff` output for the current working directory. *(FR4.1)*
+- Given the model requests `git_diff` with a path or ref argument, when chat-cli runs it, then it returns `git diff <arg>` output instead. *(FR4.1)*
+- Given the working directory isn't inside a git repository, when `git_diff` is requested, then chat-cli returns a clear error result to the model, not a fatal CLI crash. *(FR4.3)*
+- Given `git_diff` is read-only, when the model requests it, then it executes immediately with no confirmation gate. *(FR4.2)*
+
+**INVEST**: Small, fully independent of Epic 8 (no gate involved) - the simplest story in this initiative.
+
+---
+
+## Epic 8 — Confirmation and Sticky Approval (FR5-FR7, [#86](https://github.com/chat-cli/chat-cli/issues/86))
+
+### Story 8.1 — First-time confirmation for a destructive call
+**As** the chat-cli User, **I want** to see exactly what a destructive tool call will do before it happens, **so that** I stay in control of file writes and shell commands.
+
+**Acceptance Criteria**:
+- Given the model requests `write_file`, when no existing approval matches, then I'm shown the target path and the content that will be written, and asked to decide before anything happens. *(FR5.1)*
+- Given the model requests `run_shell`, when no existing approval matches, then I'm shown the exact command string and asked to decide before anything runs. *(FR5.1)*
+- Given I'm shown the prompt, when I respond, then my options are exactly: approve once, approve for this session, approve always, or deny. *(FR5.2)*
+
+**INVEST**: Independent of Stories 8.2/8.3 (this is the "no prior approval exists" path); testable by asserting the prompt content and that execution blocks until a decision is made.
+
+### Story 8.2 — Sticky approval is remembered and reused
+**As** the chat-cli User, **I want** an "always" or "this session" approval to actually skip future prompts for matching calls, **so that** I'm not re-asked the same thing repeatedly.
+
+**Acceptance Criteria**:
+- Given I approved a `run_shell` call "for this session," when the model later requests another `run_shell` call with the same base command, then it executes without a new prompt, for the remainder of that session only. *(FR5.2, FR6.1, FR6.3, FR7.2)*
+- Given I approved a `write_file` call "always," when the model later requests another `write_file` call under the same directory (in a later `chat` session, same repository), then it executes without a new prompt. *(FR5.2, FR6.2, FR6.3, FR7.1)*
+- Given an "always" approval was granted in one repository, when I run `chat-cli` from a different, unrelated repository, then that approval does not apply there - the gate prompts again. *(FR7.1)*
+
+**INVEST**: Depends on Story 8.1's gate existing, but independently testable against the pattern-matching and storage logic directly (no need to drive the actual prompt UI to test whether a stored pattern matches).
+
+### Story 8.3 — Denying a destructive call
+**As** the chat-cli User, **I want** to be able to say no to a specific destructive call, **so that** the model can't force an action I don't want.
+
+**Acceptance Criteria**:
+- Given I'm shown the confirmation prompt, when I choose deny, then the action does not execute, and the model receives an error `ToolResultBlock` indicating I declined, not a fatal error. *(FR5.3)*
+- Given I denied one call, when the model tries the exact same or a similar call again later in the conversation, then I'm prompted again (a denial is not itself sticky). *(FR5.2, FR5.3)*
+
+**INVEST**: Small, independent - the "unhappy path" companion to Story 8.1.
+
+---
+
+## Traceability Summary (Initiative 3, #86)
+
+| Story | Epic | FR/NFR IDs | Issue |
+|---|---|---|---|
+| 6.1 | Automatic Enablement | FR1.1, FR1.4 | #86 |
+| 6.2 | Graceful Degradation | FR1.2, FR1.3 | #86 |
+| 7.1 | `write_file` | FR2.1-FR2.3, NFR1 | #86 |
+| 7.2 | `run_shell` | FR3.1-FR3.2, NFR2 | #86 |
+| 7.3 | `git_diff` | FR4.1-FR4.3 | #86 |
+| 8.1 | First-time confirmation | FR5.1-FR5.2 | #86 |
+| 8.2 | Sticky approval reuse | FR5.2, FR6.1-FR6.3, FR7.1-FR7.2 | #86 |
+| 8.3 | Denial | FR5.2-FR5.3 | #86 |
+
+NFR3 (revised backward compatibility - intentional default-behavior change), NFR4 (TDD/coverage), NFR5 (usability of the confirmation prompt) apply across all 8 stories in this initiative.

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -240,6 +240,21 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 			registry.Register(tools.NewReadFileTool())
 		}
 
+		// The permission gate is constructed unconditionally: it's inert
+		// until a registered tool actually requires confirmation (none do
+		// yet - read_file is read-only), but building it here means every
+		// unit that adds a destructive tool doesn't need to touch this
+		// wiring again.
+		var repoRoot string
+		if toolCwd, cwdErr := os.Getwd(); cwdErr == nil {
+			repoRoot = utils.FindGitBoundary(toolCwd)
+		}
+		approvalStore, approvalStoreErr := tools.NewApprovalStore(fm.ConfigPath, repoRoot)
+		if approvalStoreErr != nil {
+			log.Fatalf("unable to initialize tool approval store: %v", approvalStoreErr)
+		}
+		permissionGate := NewInteractivePermissionGate(approvalStore, os.Stdin, os.Stdout)
+
 		sendFn := func(ctx context.Context, in *bedrockruntime.ConverseStreamInput) (<-chan types.ConverseStreamOutput, error) {
 			out, streamErr := converseStreamWithFallbacks(ctx, svc, in)
 			if streamErr != nil {
@@ -371,11 +386,11 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 				return nil
 			}
 
-			out, err := runChatTurnWithTools(context.Background(), sendFn, converseStreamInput, registry, onText, onReasoning)
+			out, err := runChatTurnWithTools(context.Background(), sendFn, converseStreamInput, registry, permissionGate, onText, onReasoning)
 			if err != nil && hasSystemCachePoint(converseStreamInput.System) {
 				log.Printf("prompt caching not supported for this request, retrying without it: %v", err)
 				converseStreamInput.System = stripSystemCachePoints(converseStreamInput.System)
-				out, err = runChatTurnWithTools(context.Background(), sendFn, converseStreamInput, registry, onText, onReasoning)
+				out, err = runChatTurnWithTools(context.Background(), sendFn, converseStreamInput, registry, permissionGate, onText, onReasoning)
 			}
 
 			if err != nil {

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -84,11 +84,6 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 			log.Fatalf("unable to get flag: %v", err)
 		}
 
-		toolsEnabled, err := flagCmd.PersistentFlags().GetBool("tools")
-		if err != nil {
-			log.Fatalf("unable to get flag: %v", err)
-		}
-
 		thinkingEnabled, err := flagCmd.PersistentFlags().GetBool("thinking")
 		if err != nil {
 			log.Fatalf("unable to get flag: %v", err)
@@ -231,17 +226,14 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 			AdditionalModelRequestFields: buildReasoningConfig(modelIdString, thinkingEnabled, thinkingBudget, thinkingEffort),
 		}
 
-		// Tool registry is empty (and therefore inert - ToolConfiguration()
-		// returns nil, request shape unchanged) unless --tools is set, since
-		// Bedrock has no way to report whether a given model supports tool
-		// use and we don't want to break chat for models that don't.
+		// Tool use is always available - if a model/request rejects the
+		// ToolConfiguration field, converseStreamWithFallbacks retries once
+		// without it and this session continues with tools disabled.
 		registry := tools.NewRegistry()
-		if toolsEnabled {
-			registry.Register(tools.NewReadFileTool())
-			registry.Register(tools.NewWriteFileTool())
-			registry.Register(tools.NewRunShellTool())
-			registry.Register(tools.NewGitDiffTool())
-		}
+		registry.Register(tools.NewReadFileTool())
+		registry.Register(tools.NewWriteFileTool())
+		registry.Register(tools.NewRunShellTool())
+		registry.Register(tools.NewGitDiffTool())
 
 		// The permission gate is constructed unconditionally: it's inert
 		// unless a registered tool actually requires confirmation.

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -238,13 +238,14 @@ To resume an existing conversation, use: chat-cli --chat-id <id>`,
 		registry := tools.NewRegistry()
 		if toolsEnabled {
 			registry.Register(tools.NewReadFileTool())
+			registry.Register(tools.NewWriteFileTool())
+			registry.Register(tools.NewRunShellTool())
+			registry.Register(tools.NewGitDiffTool())
 		}
 
 		// The permission gate is constructed unconditionally: it's inert
-		// until a registered tool actually requires confirmation (none do
-		// yet - read_file is read-only), but building it here means every
-		// unit that adds a destructive tool doesn't need to touch this
-		// wiring again.
+		// unless a registered tool actually requires confirmation.
+		// write_file/run_shell do; read_file/git_diff don't.
 		var repoRoot string
 		if toolCwd, cwdErr := os.Getwd(); cwdErr == nil {
 			repoRoot = utils.FindGitBoundary(toolCwd)

--- a/cmd/inferenceconfig.go
+++ b/cmd/inferenceconfig.go
@@ -65,6 +65,24 @@ func isDeprecatedSamplingParamsError(err error) bool {
 	return strings.Contains(msg, "temperature") || strings.Contains(msg, "top_p") || strings.Contains(msg, "topp")
 }
 
+// isToolUseUnsupportedError reports whether err looks like Bedrock rejecting
+// a request because the model/request doesn't support tool use. UNVERIFIED
+// against real Bedrock error text (no live credentials available) - a
+// best-effort heuristic in the same spirit as isDeprecatedSamplingParamsError,
+// flagged for real-credential verification (see build-and-test-summary.md).
+func isToolUseUnsupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "tool") {
+		return false
+	}
+
+	return strings.Contains(msg, "not supported") || strings.Contains(msg, "does not support") || strings.Contains(msg, "unsupported")
+}
+
 func converseWithFallbacks(ctx context.Context, svc *bedrockruntime.Client, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
 	output, err := svc.Converse(ctx, input)
 	if err == nil {
@@ -104,6 +122,15 @@ func converseStreamWithFallbacks(ctx context.Context, svc *bedrockruntime.Client
 		if len(input.Messages) > 0 {
 			input.Messages[0].Content = stripContentCachePoints(input.Messages[0].Content)
 		}
+		output, err = svc.ConverseStream(ctx, input)
+		if err == nil {
+			return output, nil
+		}
+	}
+
+	if input.ToolConfig != nil && isToolUseUnsupportedError(err) {
+		log.Printf("tool use not supported for this model, retrying without tools: %v", err)
+		input.ToolConfig = nil
 		output, err = svc.ConverseStream(ctx, input)
 		if err == nil {
 			return output, nil

--- a/cmd/inferenceconfig_test.go
+++ b/cmd/inferenceconfig_test.go
@@ -140,3 +140,55 @@ func TestIsDeprecatedSamplingParamsError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsToolUseUnsupportedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("model not found"),
+			want: false,
+		},
+		{
+			name: "tool use not supported",
+			err:  errors.New("The model returned the following errors: tool use is not supported for this model."),
+			want: true,
+		},
+		{
+			name: "tool use does not support",
+			err:  errors.New("This model does not support tool use."),
+			want: true,
+		},
+		{
+			name: "unsupported tool",
+			err:  errors.New("unsupported tool configuration for this model."),
+			want: true,
+		},
+		{
+			name: "mentions tool but no matching qualifier",
+			err:  errors.New("invalid tool input schema"),
+			want: false,
+		},
+		{
+			name: "matching qualifier but no mention of tool",
+			err:  errors.New("prompt caching is not supported for this model."),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isToolUseUnsupportedError(tt.err); got != tt.want {
+				t.Fatalf("isToolUseUnsupportedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/permissionprompt.go
+++ b/cmd/permissionprompt.go
@@ -1,0 +1,81 @@
+/*
+Copyright © 2024 Micah Walter
+*/
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/chat-cli/chat-cli/tools"
+)
+
+// InteractivePermissionGate is the concrete, terminal-facing PermissionGate
+// implementation: it shows the confirmation prompt, reads the user's
+// once/session/always/deny choice, and records the decision via an
+// ApprovalStore.
+type InteractivePermissionGate struct {
+	store  *tools.ApprovalStore
+	reader io.Reader
+	writer io.Writer
+}
+
+// NewInteractivePermissionGate creates a gate backed by store, reading
+// prompt responses from reader and writing prompt text to writer. In
+// production these are os.Stdin/os.Stdout; tests inject a strings.Reader/
+// bytes.Buffer so the parsing logic is testable without a real terminal.
+func NewInteractivePermissionGate(store *tools.ApprovalStore, reader io.Reader, writer io.Writer) *InteractivePermissionGate {
+	return &InteractivePermissionGate{store: store, reader: reader, writer: writer}
+}
+
+// Check implements tools.PermissionGate. A prior session/always approval
+// (BR6) short-circuits without printing anything or reading any input.
+// Otherwise it prints the summary and choice prompt, reads one line, and
+// parses the first non-whitespace character (BR12): o/s/a/n, case
+// insensitive. "a" (always) is only offered/accepted when the store's
+// approvals can actually be persisted (BR10 - inside a git repository);
+// any unrecognized or empty/EOF input defaults to deny, fail-closed (BR12).
+func (g *InteractivePermissionGate) Check(toolName, patternKey, summary string) tools.Decision {
+	if g.store.IsApproved(toolName, patternKey) {
+		return tools.DecisionAllowOnce
+	}
+
+	offerAlways := g.store.CanRecordAlways()
+
+	fmt.Fprintf(g.writer, "%s\n", summary)
+	if offerAlways {
+		fmt.Fprint(g.writer, "Allow this action? [o]nce / [s]ession / [a]lways / [n]o: ")
+	} else {
+		fmt.Fprint(g.writer, "Allow this action? [o]nce / [s]ession / [n]o: ")
+	}
+
+	line, _ := bufio.NewReader(g.reader).ReadString('\n')
+	choice := strings.ToLower(strings.TrimSpace(line))
+
+	var decision tools.Decision
+	switch {
+	case choice == "o":
+		decision = tools.DecisionAllowOnce
+	case choice == "s":
+		decision = tools.DecisionAllowSession
+	case choice == "a" && offerAlways:
+		decision = tools.DecisionAllowAlways
+	case choice == "n":
+		decision = tools.DecisionDeny
+	default:
+		decision = tools.DecisionDeny
+	}
+
+	switch decision {
+	case tools.DecisionAllowSession:
+		g.store.RecordSession(toolName, patternKey)
+	case tools.DecisionAllowAlways:
+		if err := g.store.RecordAlways(toolName, patternKey); err != nil {
+			fmt.Fprintf(g.writer, "warning: failed to persist approval: %v\n", err)
+		}
+	}
+
+	return decision
+}

--- a/cmd/permissionprompt_test.go
+++ b/cmd/permissionprompt_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright © 2024 Micah Walter
+*/
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chat-cli/chat-cli/tools"
+)
+
+func newTestApprovalStore(t *testing.T, repoRoot string) *tools.ApprovalStore {
+	t.Helper()
+	store, err := tools.NewApprovalStore(t.TempDir(), repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error creating ApprovalStore: %v", err)
+	}
+	return store
+}
+
+func TestInteractivePermissionGate_ChoiceParsing(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  tools.Decision
+	}{
+		{"once, lowercase", "o\n", tools.DecisionAllowOnce},
+		{"once, uppercase", "O\n", tools.DecisionAllowOnce},
+		{"session, lowercase", "s\n", tools.DecisionAllowSession},
+		{"session, uppercase", "S\n", tools.DecisionAllowSession},
+		{"always, lowercase", "a\n", tools.DecisionAllowAlways},
+		{"always, uppercase", "A\n", tools.DecisionAllowAlways},
+		{"deny, lowercase", "n\n", tools.DecisionDeny},
+		{"deny, uppercase", "N\n", tools.DecisionDeny},
+		{"empty input defaults to deny", "\n", tools.DecisionDeny},
+		{"EOF (no newline at all) defaults to deny", "", tools.DecisionDeny},
+		{"unrecognized character defaults to deny", "x\n", tools.DecisionDeny},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestApprovalStore(t, "/repo")
+			var out bytes.Buffer
+			gate := NewInteractivePermissionGate(store, strings.NewReader(tt.input), &out)
+
+			got := gate.Check("run_shell", "git", "run `git diff`")
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestInteractivePermissionGate_SessionChoiceIsRemembered(t *testing.T) {
+	store := newTestApprovalStore(t, "/repo")
+	var out bytes.Buffer
+	gate := NewInteractivePermissionGate(store, strings.NewReader("s\n"), &out)
+
+	gate.Check("run_shell", "git", "run `git diff`")
+
+	if !store.IsApproved("run_shell", "git") {
+		t.Error("expected a session choice to record a session approval")
+	}
+}
+
+func TestInteractivePermissionGate_AlwaysChoiceIsPersisted(t *testing.T) {
+	store := newTestApprovalStore(t, "/repo")
+	var out bytes.Buffer
+	gate := NewInteractivePermissionGate(store, strings.NewReader("a\n"), &out)
+
+	gate.Check("run_shell", "git", "run `git diff`")
+
+	if !store.IsApproved("run_shell", "git") {
+		t.Error("expected an always choice to record an approval")
+	}
+}
+
+func TestInteractivePermissionGate_AlwaysNotOfferedOutsideARepo(t *testing.T) {
+	store := newTestApprovalStore(t, "") // no repo root
+	var out bytes.Buffer
+	gate := NewInteractivePermissionGate(store, strings.NewReader("a\n"), &out)
+
+	got := gate.Check("run_shell", "git", "run `git diff`")
+
+	if got != tools.DecisionDeny {
+		t.Errorf("expected 'a' to be treated as unrecognized (deny) when always isn't offered, got %v", got)
+	}
+	if strings.Contains(strings.ToLower(out.String()), "always") {
+		t.Errorf("expected the prompt to not mention 'always' when outside a repo, got: %s", out.String())
+	}
+}
+
+func TestInteractivePermissionGate_PriorApprovalSkipsThePrompt(t *testing.T) {
+	store := newTestApprovalStore(t, "/repo")
+	store.RecordSession("run_shell", "git")
+	var out bytes.Buffer
+	// No input available - if the gate tried to read a prompt response, it
+	// would get EOF and deny. A pre-existing approval must short-circuit
+	// before any read happens.
+	gate := NewInteractivePermissionGate(store, strings.NewReader(""), &out)
+
+	got := gate.Check("run_shell", "git", "run `git diff`")
+
+	if got == tools.DecisionDeny {
+		t.Error("expected a pre-existing approval to skip the prompt and allow the call")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no prompt to be printed when an approval already exists, got: %s", out.String())
+	}
+}

--- a/cmd/projectcontext.go
+++ b/cmd/projectcontext.go
@@ -7,15 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/chat-cli/chat-cli/utils"
 )
 
 // maxContextFileSize is the size (in bytes) at which project-context file
 // content is truncated before being used as the system prompt (BR9).
 const maxContextFileSize = 32 * 1024
-
-// maxWalkUpLevels bounds the upward .git-boundary search (NFR design note)
-// as a defensive cap against a pathologically deep cwd with no repo above it.
-const maxWalkUpLevels = 64
 
 // defaultContextFilenames is the default precedence list (BR5) used when the
 // context-files config key is unset.
@@ -61,7 +59,7 @@ func findProjectContextFile(cwd string, candidates []string) (path string, match
 		return path, matched, true
 	}
 
-	boundary := findGitBoundary(cwd)
+	boundary := utils.FindGitBoundary(cwd)
 	if boundary == "" || boundary == cwd {
 		return "", "", false
 	}
@@ -109,26 +107,6 @@ func formatProjectContextDisplayPath(cwd, sourcePath string) string {
 		return rel
 	}
 	return filepath.Base(sourcePath)
-}
-
-// findGitBoundary walks upward from dir looking for the first ancestor
-// (inclusive) containing a .git entry, capped at maxWalkUpLevels. Returns ""
-// if none is found.
-func findGitBoundary(dir string) string {
-	current := dir
-	for i := 0; i < maxWalkUpLevels; i++ {
-		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
-			return current
-		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			// reached filesystem root
-			return ""
-		}
-		current = parent
-	}
-	return ""
 }
 
 // loadProjectContext implements BR7-BR10: reads path, trims surrounding

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,6 @@ func init() {
 	rootCmd.PersistentFlags().String("chat-id", "", "pass a valid chat-id to load a previous conversation")
 	rootCmd.PersistentFlags().String("system", "", "set a system prompt")
 	rootCmd.PersistentFlags().Bool("no-context-file", false, "disable automatic project-context file discovery (AGENTS.md/CLAUDE.md/etc., chat only)")
-	rootCmd.PersistentFlags().Bool("tools", false, "enable tool use (chat only)")
 	rootCmd.PersistentFlags().Bool("thinking", false, "enable extended thinking / reasoning mode")
 	rootCmd.PersistentFlags().Int32("thinking-budget", 1024, "token budget for extended thinking on legacy models (requires --thinking)")
 	rootCmd.PersistentFlags().String("thinking-effort", defaultThinkingEffort, "reasoning effort for adaptive models: low, medium, or high (requires --thinking)")

--- a/cmd/toolloop.go
+++ b/cmd/toolloop.go
@@ -166,6 +166,7 @@ func runChatTurnWithTools(
 	send converseStreamFunc,
 	input *bedrockruntime.ConverseStreamInput,
 	registry *tools.Registry,
+	gate tools.PermissionGate,
 	onText utils.StreamingOutputHandler,
 	onReasoning utils.StreamingOutputHandler,
 ) (string, error) {
@@ -202,7 +203,7 @@ func runChatTurnWithTools(
 
 		var resultContent []types.ContentBlock
 		for _, call := range toolCalls {
-			result := registry.Dispatch(ctx, call)
+			result := registry.Dispatch(ctx, call, gate)
 			resultContent = append(resultContent, &types.ContentBlockMemberToolResult{Value: result})
 		}
 		input.Messages = append(input.Messages, types.Message{

--- a/cmd/toolturn_test.go
+++ b/cmd/toolturn_test.go
@@ -66,6 +66,10 @@ func (f *fakeTurnTool) InputSchema() document.Interface {
 func (f *fakeTurnTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
 	return "ok", nil
 }
+func (f *fakeTurnTool) RequiresConfirmation() bool { return false }
+func (f *fakeTurnTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) {
+	return "", "", nil
+}
 
 func TestRunChatTurnWithTools_NoToolUse(t *testing.T) {
 	callCount := 0
@@ -80,7 +84,7 @@ func TestRunChatTurnWithTools_NoToolUse(t *testing.T) {
 
 	onReasoning := func(_ context.Context, _ string) error { return nil }
 
-	result, err := runChatTurnWithTools(context.Background(), send, input, registry, onText, onReasoning)
+	result, err := runChatTurnWithTools(context.Background(), send, input, registry, nil, onText, onReasoning)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +110,7 @@ func TestRunChatTurnWithTools_RoundTripCap(t *testing.T) {
 
 	onReasoning := func(_ context.Context, _ string) error { return nil }
 
-	_, err := runChatTurnWithTools(context.Background(), send, input, registry, onText, onReasoning)
+	_, err := runChatTurnWithTools(context.Background(), send, input, registry, nil, onText, onReasoning)
 	if err == nil {
 		t.Fatal("expected an error when the round-trip cap is exceeded, got none")
 	}

--- a/tools/approvalstore.go
+++ b/tools/approvalstore.go
@@ -1,0 +1,150 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const approvalStoreFilename = "tool-approvals.yaml"
+
+// approvalStoreFile is the on-disk shape of the persisted "always" tier:
+// a map from absolute repository root to a list of "toolName:patternKey"
+// entries approved for that repository. Uses ":" (not the in-memory "\x00"
+// key) so the file stays human-readable/hand-editable, per
+// business-logic-model.md.
+type approvalStoreFile struct {
+	Repos map[string][]string `yaml:"repos"`
+}
+
+// persistedEntry formats toolName+patternKey for on-disk storage.
+func persistedEntry(toolName, patternKey string) string {
+	return toolName + ":" + patternKey
+}
+
+// ApprovalStore tracks granted sticky approvals for destructive tool calls
+// at two tiers: session (in-memory, this process only) and always
+// (persisted, scoped per git repository - see NewApprovalStore's repoRoot
+// parameter and RecordAlways).
+type ApprovalStore struct {
+	configPath string
+	repoRoot   string
+	session    map[string]bool
+	always     map[string]bool // this repo's always-approvals only, loaded at construction
+}
+
+// NewApprovalStore creates an ApprovalStore. configPath is the directory
+// chat-cli's other config/data lives in (fm.ConfigPath) - the persisted
+// "always" tier is stored there. repoRoot is the current git repository's
+// root (from utils.FindGitBoundary), or "" if not inside one - "always"
+// approvals are unavailable in that case (RecordAlways is a safe no-op).
+//
+// A missing or malformed store file degrades to zero always-approvals
+// rather than an error - consistent with #88's precedent for tolerating
+// unreadable local files.
+func NewApprovalStore(configPath, repoRoot string) (*ApprovalStore, error) {
+	s := &ApprovalStore{
+		configPath: configPath,
+		repoRoot:   repoRoot,
+		session:    make(map[string]bool),
+		always:     make(map[string]bool),
+	}
+
+	if repoRoot == "" {
+		return s, nil
+	}
+
+	data, err := os.ReadFile(s.storePath()) // #nosec G304 - configPath is chat-cli's own config directory
+	if err != nil {
+		return s, nil // missing file: zero approvals, not an error
+	}
+
+	var file approvalStoreFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return s, nil // malformed file: zero approvals, not an error
+	}
+
+	for _, entry := range file.Repos[repoRoot] {
+		toolName, patternKey, ok := strings.Cut(entry, ":")
+		if !ok {
+			continue // malformed entry, skip rather than fail the whole load
+		}
+		s.always[approvalKey(toolName, patternKey)] = true
+	}
+
+	return s, nil
+}
+
+func (s *ApprovalStore) storePath() string {
+	return filepath.Join(s.configPath, approvalStoreFilename)
+}
+
+// approvalKey joins toolName and patternKey with a NUL byte, which can't
+// appear in either component, avoiding any delimiter-collision edge case a
+// printable separator like ":" could hit if a pattern key ever contained one.
+func approvalKey(toolName, patternKey string) string {
+	return toolName + "\x00" + patternKey
+}
+
+// IsApproved reports whether toolName+patternKey has a matching approval in
+// either tier (session checked first, then always).
+func (s *ApprovalStore) IsApproved(toolName, patternKey string) bool {
+	key := approvalKey(toolName, patternKey)
+	return s.session[key] || s.always[key]
+}
+
+// CanRecordAlways reports whether this store has a repository root to scope
+// "always" approvals to (BR10) - false when chat isn't running inside a git
+// repository, in which case "always" should not be offered as a choice.
+func (s *ApprovalStore) CanRecordAlways() bool {
+	return s.repoRoot != ""
+}
+
+// RecordSession grants an in-memory-only approval for the rest of this
+// process's lifetime.
+func (s *ApprovalStore) RecordSession(toolName, patternKey string) {
+	s.session[approvalKey(toolName, patternKey)] = true
+}
+
+// RecordAlways grants an approval persisted to disk, scoped to this store's
+// repoRoot. A safe no-op (no error, no file written) when repoRoot is empty
+// (not inside a git repository) - there's no meaningful root to scope it to.
+func (s *ApprovalStore) RecordAlways(toolName, patternKey string) error {
+	if s.repoRoot == "" {
+		return nil
+	}
+
+	s.always[approvalKey(toolName, patternKey)] = true
+	entry := persistedEntry(toolName, patternKey)
+
+	file := approvalStoreFile{Repos: make(map[string][]string)}
+
+	if data, err := os.ReadFile(s.storePath()); err == nil { // #nosec G304 - configPath is chat-cli's own config directory
+		_ = yaml.Unmarshal(data, &file) // best-effort merge; a malformed existing file is overwritten below
+		if file.Repos == nil {
+			file.Repos = make(map[string][]string)
+		}
+	}
+
+	entries := file.Repos[s.repoRoot]
+	found := false
+	for _, e := range entries {
+		if e == entry {
+			found = true
+			break
+		}
+	}
+	if !found {
+		entries = append(entries, entry)
+	}
+	file.Repos[s.repoRoot] = entries
+
+	out, err := yaml.Marshal(file)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(s.storePath(), out, 0600)
+}

--- a/tools/approvalstore_test.go
+++ b/tools/approvalstore_test.go
@@ -1,0 +1,139 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApprovalStore_SessionTier(t *testing.T) {
+	t.Run("not approved before any record", func(t *testing.T) {
+		s, err := NewApprovalStore(t.TempDir(), "/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.IsApproved("run_shell", "git") {
+			t.Error("expected no approval before any record")
+		}
+	})
+
+	t.Run("approved after RecordSession", func(t *testing.T) {
+		s, err := NewApprovalStore(t.TempDir(), "/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s.RecordSession("run_shell", "git")
+		if !s.IsApproved("run_shell", "git") {
+			t.Error("expected approval after RecordSession")
+		}
+	})
+
+	t.Run("approvals are independent per tool+pattern pair", func(t *testing.T) {
+		s, err := NewApprovalStore(t.TempDir(), "/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s.RecordSession("run_shell", "git")
+
+		if s.IsApproved("run_shell", "npm") {
+			t.Error("did not expect a different pattern key to be approved")
+		}
+		if s.IsApproved("write_file", "git") {
+			t.Error("did not expect a different tool with the same pattern key to be approved")
+		}
+	})
+}
+
+func TestApprovalStore_AlwaysTier(t *testing.T) {
+	t.Run("RecordAlways persists with 0600 permissions and is loaded by a fresh store", func(t *testing.T) {
+		configPath := t.TempDir()
+
+		s1, err := NewApprovalStore(configPath, "/repo/a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := s1.RecordAlways("run_shell", "git"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		storePath := filepath.Join(configPath, "tool-approvals.yaml")
+		info, err := os.Stat(storePath)
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", storePath, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("expected 0600 permissions, got %o", perm)
+		}
+
+		s2, err := NewApprovalStore(configPath, "/repo/a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !s2.IsApproved("run_shell", "git") {
+			t.Error("expected a fresh store pointed at the same configPath/repoRoot to see the persisted approval")
+		}
+	})
+
+	t.Run("always approvals do not leak across different repository roots", func(t *testing.T) {
+		configPath := t.TempDir()
+
+		s1, err := NewApprovalStore(configPath, "/repo/a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := s1.RecordAlways("run_shell", "git"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		s2, err := NewApprovalStore(configPath, "/repo/b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s2.IsApproved("run_shell", "git") {
+			t.Error("expected an always-approval in one repo root to not apply in a different one")
+		}
+	})
+
+	t.Run("a missing store file yields zero approvals, not an error", func(t *testing.T) {
+		s, err := NewApprovalStore(t.TempDir(), "/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.IsApproved("run_shell", "git") {
+			t.Error("expected no approvals from a missing store file")
+		}
+	})
+
+	t.Run("a malformed store file yields zero approvals, not a fatal error", func(t *testing.T) {
+		configPath := t.TempDir()
+		storePath := filepath.Join(configPath, "tool-approvals.yaml")
+		if err := os.WriteFile(storePath, []byte("not: valid: yaml: [["), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		s, err := NewApprovalStore(configPath, "/repo")
+		if err != nil {
+			t.Fatalf("expected malformed store file to degrade gracefully, got error: %v", err)
+		}
+		if s.IsApproved("run_shell", "git") {
+			t.Error("expected no approvals from a malformed store file")
+		}
+	})
+
+	t.Run("RecordAlways is a safe no-op when repoRoot is empty", func(t *testing.T) {
+		configPath := t.TempDir()
+		s, err := NewApprovalStore(configPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := s.RecordAlways("run_shell", "git"); err != nil {
+			t.Fatalf("expected RecordAlways to be a safe no-op outside a repo, got error: %v", err)
+		}
+		if s.IsApproved("run_shell", "git") {
+			t.Error("expected no approval to be recorded when repoRoot is empty")
+		}
+		if _, err := os.Stat(filepath.Join(configPath, "tool-approvals.yaml")); err == nil {
+			t.Error("expected no store file to be created when repoRoot is empty")
+		}
+	})
+}

--- a/tools/gitdiff.go
+++ b/tools/gitdiff.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+)
+
+// GitDiffTool is a read-only built-in tool that runs `git diff` in the
+// working directory. It never requires confirmation.
+type GitDiffTool struct{}
+
+// NewGitDiffTool creates a GitDiffTool.
+func NewGitDiffTool() *GitDiffTool {
+	return &GitDiffTool{}
+}
+
+func (t *GitDiffTool) Name() string {
+	return "git_diff"
+}
+
+func (t *GitDiffTool) Description() string {
+	return "Show the working tree diff (git diff) for the current repository, optionally scoped to a path or ref."
+}
+
+func (t *GitDiffTool) InputSchema() document.Interface {
+	return document.NewLazyDocument(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"arg": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional path or ref to pass to `git diff`, e.g. a filename or commit.",
+			},
+		},
+	})
+}
+
+type gitDiffInput struct {
+	Arg string `json:"arg"`
+}
+
+func (t *GitDiffTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var params gitDiffInput
+	// Empty input ({}) is valid - arg is optional - so only a genuine parse
+	// error (malformed JSON) is treated as invalid input.
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &params); err != nil {
+			return "", fmt.Errorf("invalid tool input: %w", err)
+		}
+	}
+
+	args := []string{"diff"}
+	if params.Arg != "" {
+		args = append(args, params.Arg)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 - arg is passed as a single exec.Command argument, never shell-interpreted
+	if cwd, err := os.Getwd(); err == nil {
+		cmd.Dir = cwd
+	}
+
+	output, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return "", fmt.Errorf("git diff failed: %s", string(output))
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to run git diff: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func (t *GitDiffTool) RequiresConfirmation() bool {
+	return false
+}
+
+func (t *GitDiffTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) {
+	return "", "", nil
+}

--- a/tools/gitdiff_test.go
+++ b/tools/gitdiff_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitDiffTool_RequiresConfirmation(t *testing.T) {
+	tool := NewGitDiffTool()
+	if tool.RequiresConfirmation() {
+		t.Error("expected git_diff to not require confirmation - it's read-only")
+	}
+}
+
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("line1\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "file.txt")
+	runGit("commit", "-q", "-m", "initial")
+
+	if err := os.WriteFile(filePath, []byte("line1\nline2\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func chdirToRepo(t *testing.T, dir string) {
+	t.Helper()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Errorf("failed to change back to original directory: %v", err)
+		}
+	})
+}
+
+func TestGitDiffTool_Execute(t *testing.T) {
+	t.Run("no arg runs a plain git diff", func(t *testing.T) {
+		chdirToRepo(t, initTestGitRepo(t))
+		tool := NewGitDiffTool()
+
+		output, err := tool.Execute(context.Background(), []byte(`{}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(output, "line2") {
+			t.Errorf("expected diff output to contain the new line, got %q", output)
+		}
+	})
+
+	t.Run("an arg is passed through", func(t *testing.T) {
+		chdirToRepo(t, initTestGitRepo(t))
+		tool := NewGitDiffTool()
+
+		output, err := tool.Execute(context.Background(), []byte(`{"arg":"file.txt"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(output, "line2") {
+			t.Errorf("expected diff output to contain the new line, got %q", output)
+		}
+	})
+
+	t.Run("outside a git repository returns git's own error", func(t *testing.T) {
+		chdirToRepo(t, t.TempDir())
+		tool := NewGitDiffTool()
+
+		_, err := tool.Execute(context.Background(), []byte(`{}`))
+		if err == nil {
+			t.Fatal("expected an error when not inside a git repository")
+		}
+	})
+}

--- a/tools/permission.go
+++ b/tools/permission.go
@@ -1,0 +1,26 @@
+package tools
+
+// Decision is the outcome of a PermissionGate.Check call for a specific
+// destructive tool invocation.
+type Decision int
+
+const (
+	// DecisionAllowOnce permits this specific call, without recording any
+	// sticky approval.
+	DecisionAllowOnce Decision = iota
+	// DecisionAllowSession permits this call and all future calls matching
+	// the same tool+pattern key for the remainder of the current process.
+	DecisionAllowSession
+	// DecisionAllowAlways permits this call and persists the approval so
+	// future chat sessions in the same repository skip the prompt too.
+	DecisionAllowAlways
+	// DecisionDeny refuses this call. Denials are never sticky.
+	DecisionDeny
+)
+
+// PermissionGate decides whether a destructive tool call may proceed.
+// Registry.Dispatch consults it before calling Execute on any tool whose
+// RequiresConfirmation returns true.
+type PermissionGate interface {
+	Check(toolName, patternKey, summary string) Decision
+}

--- a/tools/readfile.go
+++ b/tools/readfile.go
@@ -62,3 +62,11 @@ func (t *ReadFileTool) Execute(_ context.Context, input json.RawMessage) (string
 
 	return string(data), nil
 }
+
+func (t *ReadFileTool) RequiresConfirmation() bool {
+	return false
+}
+
+func (t *ReadFileTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) {
+	return "", "", nil
+}

--- a/tools/readfile_test.go
+++ b/tools/readfile_test.go
@@ -65,3 +65,10 @@ func TestReadFileTool_Execute(t *testing.T) {
 		}
 	})
 }
+
+func TestReadFileTool_RequiresConfirmation(t *testing.T) {
+	tool := NewReadFileTool()
+	if tool.RequiresConfirmation() {
+		t.Error("expected read_file to not require confirmation - it's read-only")
+	}
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -61,10 +61,26 @@ func (r *Registry) ToolConfiguration() *types.ToolConfiguration {
 // returns a ToolResultBlock (success or error) - it never panics and never
 // returns a Go error, so callers can send the result straight back to the
 // model without special-casing failure.
-func (r *Registry) Dispatch(ctx context.Context, call ToolCall) types.ToolResultBlock {
+//
+// If the tool requires confirmation, gate.Check is consulted before Execute
+// is called (BR3-BR6, BR11). gate may be nil only when no registered tool
+// requires confirmation - Dispatch never dereferences a nil gate for a
+// non-destructive tool.
+func (r *Registry) Dispatch(ctx context.Context, call ToolCall, gate PermissionGate) types.ToolResultBlock {
 	tool, ok := r.tools[call.Name]
 	if !ok {
 		return errorResult(call.ToolUseID, fmt.Sprintf("unknown tool: %s", call.Name))
+	}
+
+	if tool.RequiresConfirmation() {
+		summary, patternKey, err := tool.ConfirmationSummary(call.Input)
+		if err != nil {
+			return errorResult(call.ToolUseID, fmt.Sprintf("invalid tool input: %s", err.Error()))
+		}
+
+		if gate.Check(tool.Name(), patternKey, summary) == DecisionDeny {
+			return errorResult(call.ToolUseID, "user declined this action")
+		}
 	}
 
 	output, err := tool.Execute(ctx, call.Input)

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -28,6 +28,46 @@ func (f *fakeTool) Execute(_ context.Context, _ json.RawMessage) (string, error)
 	}
 	return f.result, nil
 }
+func (f *fakeTool) RequiresConfirmation() bool { return false }
+func (f *fakeTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) {
+	return "", "", nil
+}
+
+// fakeDestructiveTool is a test double for a destructive tool that requires
+// confirmation, with a controllable ConfirmationSummary outcome.
+type fakeDestructiveTool struct {
+	name       string
+	result     string
+	summaryErr error
+}
+
+func (f *fakeDestructiveTool) Name() string        { return f.name }
+func (f *fakeDestructiveTool) Description() string { return "a fake destructive tool for tests" }
+func (f *fakeDestructiveTool) InputSchema() document.Interface {
+	return document.NewLazyDocument(map[string]interface{}{"type": "object"})
+}
+func (f *fakeDestructiveTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return f.result, nil
+}
+func (f *fakeDestructiveTool) RequiresConfirmation() bool { return true }
+func (f *fakeDestructiveTool) ConfirmationSummary(_ json.RawMessage) (string, string, error) {
+	if f.summaryErr != nil {
+		return "", "", f.summaryErr
+	}
+	return "will do something destructive", "pattern-key", nil
+}
+
+// fakeGate is a test double for PermissionGate returning a fixed Decision
+// and recording whether Check was called.
+type fakeGate struct {
+	decision Decision
+	called   bool
+}
+
+func (g *fakeGate) Check(_, _, _ string) Decision {
+	g.called = true
+	return g.decision
+}
 
 func TestNewRegistry_EmptyToolConfiguration(t *testing.T) {
 	r := NewRegistry()
@@ -57,7 +97,7 @@ func TestRegistry_Dispatch_UnknownTool(t *testing.T) {
 		Name:      "nonexistent",
 		ToolUseID: "abc123",
 		Input:     []byte(`{}`),
-	})
+	}, nil)
 
 	if result.Status != types.ToolResultStatusError {
 		t.Errorf("expected error status for unknown tool, got %v", result.Status)
@@ -75,7 +115,7 @@ func TestRegistry_Dispatch_Success(t *testing.T) {
 		Name:      "fake_tool",
 		ToolUseID: "call-1",
 		Input:     []byte(`{}`),
-	})
+	}, nil)
 
 	if result.Status != types.ToolResultStatusSuccess {
 		t.Errorf("expected success status, got %v", result.Status)
@@ -100,7 +140,7 @@ func TestRegistry_Dispatch_ExecutionError(t *testing.T) {
 		Name:      "fake_tool",
 		ToolUseID: "call-2",
 		Input:     []byte(`{}`),
-	})
+	}, nil)
 
 	if result.Status != types.ToolResultStatusError {
 		t.Errorf("expected error status when tool execution fails, got %v", result.Status)
@@ -111,5 +151,90 @@ func TestRegistry_Dispatch_ExecutionError(t *testing.T) {
 	}
 	if textBlock.Value != "boom" {
 		t.Errorf("expected error text %q, got %q", "boom", textBlock.Value)
+	}
+}
+
+func TestRegistry_Dispatch_NonDestructiveToolNeverConsultsGate(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&fakeTool{name: "fake_tool", result: "ok"})
+	gate := &fakeGate{decision: DecisionDeny} // if consulted, would deny - proves it wasn't consulted
+
+	result := r.Dispatch(context.Background(), ToolCall{
+		Name:      "fake_tool",
+		ToolUseID: "call-3",
+		Input:     []byte(`{}`),
+	}, gate)
+
+	if gate.called {
+		t.Error("expected the gate to never be consulted for a non-destructive tool")
+	}
+	if result.Status != types.ToolResultStatusSuccess {
+		t.Errorf("expected success status, got %v", result.Status)
+	}
+}
+
+func TestRegistry_Dispatch_ConfirmationSummaryErrorNeverReachesGateOrExecute(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&fakeDestructiveTool{name: "destructive_tool", summaryErr: errors.New("bad input")})
+	gate := &fakeGate{decision: DecisionAllowOnce}
+
+	result := r.Dispatch(context.Background(), ToolCall{
+		Name:      "destructive_tool",
+		ToolUseID: "call-4",
+		Input:     []byte(`{}`),
+	}, gate)
+
+	if gate.called {
+		t.Error("expected the gate to never be consulted when ConfirmationSummary fails")
+	}
+	if result.Status != types.ToolResultStatusError {
+		t.Errorf("expected error status, got %v", result.Status)
+	}
+}
+
+func TestRegistry_Dispatch_GateDenyBlocksExecute(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&fakeDestructiveTool{name: "destructive_tool", result: "should never see this"})
+	gate := &fakeGate{decision: DecisionDeny}
+
+	result := r.Dispatch(context.Background(), ToolCall{
+		Name:      "destructive_tool",
+		ToolUseID: "call-5",
+		Input:     []byte(`{}`),
+	}, gate)
+
+	if !gate.called {
+		t.Error("expected the gate to be consulted for a destructive tool")
+	}
+	if result.Status != types.ToolResultStatusError {
+		t.Errorf("expected a declined call to return error status, got %v", result.Status)
+	}
+	textBlock, ok := result.Content[0].(*types.ToolResultContentBlockMemberText)
+	if !ok {
+		t.Fatalf("expected text content block, got %T", result.Content[0])
+	}
+	if textBlock.Value == "should never see this" {
+		t.Error("Execute must not run when the gate denies the call")
+	}
+}
+
+func TestRegistry_Dispatch_GateAllowRunsExecute(t *testing.T) {
+	for _, decision := range []Decision{DecisionAllowOnce, DecisionAllowSession, DecisionAllowAlways} {
+		r := NewRegistry()
+		r.Register(&fakeDestructiveTool{name: "destructive_tool", result: "executed"})
+		gate := &fakeGate{decision: decision}
+
+		result := r.Dispatch(context.Background(), ToolCall{
+			Name:      "destructive_tool",
+			ToolUseID: "call-6",
+			Input:     []byte(`{}`),
+		}, gate)
+
+		if !gate.called {
+			t.Errorf("decision %v: expected the gate to be consulted", decision)
+		}
+		if result.Status != types.ToolResultStatusSuccess {
+			t.Errorf("decision %v: expected success status, got %v", decision, result.Status)
+		}
 	}
 }

--- a/tools/runshell.go
+++ b/tools/runshell.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+)
+
+// defaultRunShellTimeout bounds how long a run_shell command may execute
+// before being killed (BR8) - no way for a single call to hang chat forever.
+const defaultRunShellTimeout = 30 * time.Second
+
+// maxShellOutputSize is the size (in bytes) at which run_shell's combined
+// stdout+stderr is truncated before being returned to the model (BR9).
+const maxShellOutputSize = 32 * 1024
+
+// RunShellTool is a destructive built-in tool that executes an arbitrary
+// shell command in chat-cli's working directory. Every call must pass
+// through a PermissionGate (RequiresConfirmation returns true) before
+// Execute runs - there is no command allowlist, the gate is the control.
+type RunShellTool struct {
+	timeout time.Duration
+}
+
+// NewRunShellTool creates a RunShellTool with the default 30s timeout.
+func NewRunShellTool() *RunShellTool {
+	return &RunShellTool{timeout: defaultRunShellTimeout}
+}
+
+func (t *RunShellTool) Name() string {
+	return "run_shell"
+}
+
+func (t *RunShellTool) Description() string {
+	return "Run a shell command in the current working directory."
+}
+
+func (t *RunShellTool) InputSchema() document.Interface {
+	return document.NewLazyDocument(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"command": map[string]interface{}{
+				"type":        "string",
+				"description": "The shell command to run.",
+			},
+		},
+		"required": []interface{}{"command"},
+	})
+}
+
+type runShellInput struct {
+	Command string `json:"command"`
+}
+
+func (t *RunShellTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var params runShellInput
+	if err := json.Unmarshal(input, &params); err != nil {
+		return "", fmt.Errorf("invalid tool input: %w", err)
+	}
+
+	timeout := t.timeout
+	if timeout <= 0 {
+		timeout = defaultRunShellTimeout
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.Command("sh", "-c", params.Command) // #nosec G204 - arbitrary command execution is this tool's purpose, gated by PermissionGate
+	if cwd, err := os.Getwd(); err == nil {
+		cmd.Dir = cwd
+	}
+	// Run in its own process group so a timeout can kill the whole group
+	// (e.g. a grandchild like `sleep` spawned by `sh -c`), not just the
+	// shell itself - killing only the shell leaves such children running
+	// and holding the output pipe open, which would otherwise block
+	// CombinedOutput() below well past the intended timeout.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	type result struct {
+		output []byte
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		output, err := cmd.CombinedOutput()
+		done <- result{output: output, err: err}
+	}()
+
+	select {
+	case <-runCtx.Done():
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		<-done // wait for the goroutine to unblock now that the group is dead
+		return "", fmt.Errorf("command timed out after %s", timeout)
+
+	case res := <-done:
+		output := truncateShellOutput(string(res.output))
+
+		var exitErr *exec.ExitError
+		if errors.As(res.err, &exitErr) {
+			return fmt.Sprintf("[exit code: %d]\n%s", exitErr.ExitCode(), output), nil
+		}
+		if res.err != nil {
+			// The shell itself couldn't be started - a real tool-level
+			// failure, distinct from the command it was asked to run failing.
+			return "", fmt.Errorf("unable to run command: %w", res.err)
+		}
+
+		return output, nil
+	}
+}
+
+func truncateShellOutput(output string) string {
+	if len(output) <= maxShellOutputSize {
+		return output
+	}
+	return output[:maxShellOutputSize] + "\n... (output truncated)"
+}
+
+func (t *RunShellTool) RequiresConfirmation() bool {
+	return true
+}
+
+func (t *RunShellTool) ConfirmationSummary(input json.RawMessage) (string, string, error) {
+	var params runShellInput
+	if err := json.Unmarshal(input, &params); err != nil {
+		return "", "", fmt.Errorf("invalid tool input: %w", err)
+	}
+
+	summary := "Run: " + params.Command
+
+	patternKey := ""
+	if fields := strings.Fields(params.Command); len(fields) > 0 {
+		patternKey = fields[0]
+	}
+
+	return summary, patternKey, nil
+}

--- a/tools/runshell_test.go
+++ b/tools/runshell_test.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunShellTool_RequiresConfirmation(t *testing.T) {
+	tool := NewRunShellTool()
+	if !tool.RequiresConfirmation() {
+		t.Error("expected run_shell to require confirmation")
+	}
+}
+
+func TestRunShellTool_ConfirmationSummary(t *testing.T) {
+	tool := NewRunShellTool()
+
+	t.Run("summary and pattern key", func(t *testing.T) {
+		summary, patternKey, err := tool.ConfirmationSummary([]byte(`{"command":"git diff main"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if summary != "Run: git diff main" {
+			t.Errorf("expected %q, got %q", "Run: git diff main", summary)
+		}
+		if patternKey != "git" {
+			t.Errorf("expected pattern key %q, got %q", "git", patternKey)
+		}
+	})
+
+	t.Run("empty command yields an empty pattern key", func(t *testing.T) {
+		_, patternKey, err := tool.ConfirmationSummary([]byte(`{"command":""}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if patternKey != "" {
+			t.Errorf("expected an empty pattern key, got %q", patternKey)
+		}
+	})
+}
+
+func TestRunShellTool_Execute(t *testing.T) {
+	t.Run("returns command output on success", func(t *testing.T) {
+		tool := NewRunShellTool()
+		output, err := tool.Execute(context.Background(), []byte(`{"command":"echo hello"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(output, "hello") {
+			t.Errorf("expected output to contain %q, got %q", "hello", output)
+		}
+	})
+
+	t.Run("a non-zero exit code is embedded in output, not a Go error", func(t *testing.T) {
+		tool := NewRunShellTool()
+		output, err := tool.Execute(context.Background(), []byte(`{"command":"exit 1"}`))
+		if err != nil {
+			t.Fatalf("expected no Go error for a non-zero exit, got: %v", err)
+		}
+		if !strings.Contains(output, "exit code: 1") {
+			t.Errorf("expected output to mention the exit code, got %q", output)
+		}
+	})
+
+	t.Run("a timeout returns a Go error promptly, even for a grandchild process", func(t *testing.T) {
+		tool := &RunShellTool{timeout: 50 * time.Millisecond}
+		start := time.Now()
+		// sh -c "sleep 5" makes `sleep` a grandchild - killing only the
+		// direct child (sh) must not leave Execute blocked waiting on it.
+		_, err := tool.Execute(context.Background(), []byte(`{"command":"sleep 5"}`))
+		elapsed := time.Since(start)
+
+		if err == nil {
+			t.Fatal("expected an error when the command exceeds the timeout")
+		}
+		if elapsed > 2*time.Second {
+			t.Errorf("expected Execute to return promptly after the timeout, took %s", elapsed)
+		}
+	})
+
+	t.Run("output over 32KB is truncated", func(t *testing.T) {
+		tool := NewRunShellTool()
+		output, err := tool.Execute(context.Background(), []byte(`{"command":"yes | head -c 40000"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(output) > maxShellOutputSize+200 { // allow slack for the truncation marker text
+			t.Errorf("expected output to be truncated near %d bytes, got %d", maxShellOutputSize, len(output))
+		}
+		if !strings.Contains(output, "truncated") {
+			t.Errorf("expected a truncation marker, got output of length %d", len(output))
+		}
+	})
+}

--- a/tools/tool.go
+++ b/tools/tool.go
@@ -22,4 +22,16 @@ type Tool interface {
 	// Execute runs the tool with the model-supplied input and returns a
 	// human/model-readable result, or an error if execution failed.
 	Execute(ctx context.Context, input json.RawMessage) (string, error)
+
+	// RequiresConfirmation reports whether calls to this tool must pass
+	// through a PermissionGate before Execute is called. Read-only tools
+	// return false and never have ConfirmationSummary called.
+	RequiresConfirmation() bool
+
+	// ConfirmationSummary returns human-readable text describing what a
+	// specific call will do (shown at the confirmation prompt), and a
+	// coarse pattern key used for sticky-approval matching. Only called
+	// when RequiresConfirmation returns true; an error here is treated as
+	// a denial - the call never reaches the gate or Execute.
+	ConfirmationSummary(input json.RawMessage) (summary string, patternKey string, err error)
 }

--- a/tools/writefile.go
+++ b/tools/writefile.go
@@ -1,0 +1,126 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/chat-cli/chat-cli/utils"
+)
+
+// maxWriteFileSummaryPreview is the content-length threshold past which the
+// confirmation summary shows a truncated preview instead of the full
+// content (BR4/NFR usability).
+const maxWriteFileSummaryPreview = 4 * 1024
+
+// WriteFileTool is a destructive built-in tool that creates or overwrites a
+// file within the working directory. Every call must pass through a
+// PermissionGate (RequiresConfirmation returns true) before Execute runs.
+type WriteFileTool struct{}
+
+// NewWriteFileTool creates a WriteFileTool.
+func NewWriteFileTool() *WriteFileTool {
+	return &WriteFileTool{}
+}
+
+func (t *WriteFileTool) Name() string {
+	return "write_file"
+}
+
+func (t *WriteFileTool) Description() string {
+	return "Create or overwrite a text file within the current working directory."
+}
+
+func (t *WriteFileTool) InputSchema() document.Interface {
+	return document.NewLazyDocument(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "Path to the file, relative to the current working directory.",
+			},
+			"content": map[string]interface{}{
+				"type":        "string",
+				"description": "The full content to write to the file.",
+			},
+		},
+		"required": []interface{}{"path", "content"},
+	})
+}
+
+type writeFileInput struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (t *WriteFileTool) Execute(_ context.Context, input json.RawMessage) (string, error) {
+	var params writeFileInput
+	if err := json.Unmarshal(input, &params); err != nil {
+		return "", fmt.Errorf("invalid tool input: %w", err)
+	}
+
+	fullPath, err := utils.ValidateLocalPathForWrite(params.Path)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(fullPath, []byte(params.Content), 0600); err != nil { // #nosec G306 - path is validated above; 0600 only applies when creating a new file
+		return "", fmt.Errorf("unable to write file: %w", err)
+	}
+
+	return fmt.Sprintf("wrote %d bytes to %s", len(params.Content), params.Path), nil
+}
+
+func (t *WriteFileTool) RequiresConfirmation() bool {
+	return true
+}
+
+func (t *WriteFileTool) ConfirmationSummary(input json.RawMessage) (string, string, error) {
+	var params writeFileInput
+	if err := json.Unmarshal(input, &params); err != nil {
+		return "", "", fmt.Errorf("invalid tool input: %w", err)
+	}
+
+	fullPath, err := utils.ValidateLocalPathForWrite(params.Path)
+	if err != nil {
+		return "", "", err
+	}
+
+	content := params.Content
+	if len(content) > maxWriteFileSummaryPreview {
+		content = fmt.Sprintf("%s\n... (%d bytes total, shown truncated)", content[:maxWriteFileSummaryPreview], len(params.Content))
+	}
+	summary := fmt.Sprintf("Write to %s:\n%s", params.Path, content)
+
+	patternKey := writeFilePatternKey(fullPath)
+
+	return summary, patternKey, nil
+}
+
+// writeFilePatternKey implements BR5: the resolved path's containing
+// directory, relative to the git repo root if inside one, else relative to
+// cwd itself.
+func writeFilePatternKey(fullPath string) string {
+	dir := filepath.Dir(fullPath)
+
+	root := ""
+	if cwd, err := os.Getwd(); err == nil {
+		root = utils.FindGitBoundary(cwd)
+		if root == "" {
+			root = cwd
+		}
+	}
+
+	if root == "" {
+		return dir
+	}
+
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return dir
+	}
+	return rel
+}

--- a/tools/writefile_test.go
+++ b/tools/writefile_test.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Errorf("failed to change back to original directory: %v", err)
+		}
+	})
+}
+
+func TestWriteFileTool_RequiresConfirmation(t *testing.T) {
+	tool := NewWriteFileTool()
+	if !tool.RequiresConfirmation() {
+		t.Error("expected write_file to require confirmation")
+	}
+}
+
+func TestWriteFileTool_ConfirmationSummary(t *testing.T) {
+	chdirForTest(t, t.TempDir())
+
+	t.Run("summary and pattern key without a repo", func(t *testing.T) {
+		tool := NewWriteFileTool()
+		summary, patternKey, err := tool.ConfirmationSummary([]byte(`{"path":"sub/foo.txt","content":"hello"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(summary, "sub/foo.txt") || !strings.Contains(summary, "hello") {
+			t.Errorf("expected summary to mention path and content, got %q", summary)
+		}
+		if patternKey != "sub" {
+			t.Errorf("expected pattern key %q, got %q", "sub", patternKey)
+		}
+	})
+
+	t.Run("content over 4KB is truncated in the summary", func(t *testing.T) {
+		tool := NewWriteFileTool()
+		bigContent := strings.Repeat("a", 4*1024+100)
+		input := []byte(`{"path":"big.txt","content":"` + bigContent + `"}`)
+		summary, _, err := tool.ConfirmationSummary(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(summary, bigContent) {
+			t.Error("expected content over 4KB to be truncated in the summary")
+		}
+		if !strings.Contains(summary, "truncated") {
+			t.Errorf("expected a truncation note, got %q", summary)
+		}
+	})
+
+	t.Run("path traversal attempt returns an error", func(t *testing.T) {
+		tool := NewWriteFileTool()
+		_, _, err := tool.ConfirmationSummary([]byte(`{"path":"../../../etc/passwd","content":"x"}`))
+		if err == nil {
+			t.Error("expected an error for a path outside the working directory")
+		}
+	})
+}
+
+func TestWriteFileTool_Execute(t *testing.T) {
+	chdirForTest(t, t.TempDir())
+	tool := NewWriteFileTool()
+
+	t.Run("creates a new file", func(t *testing.T) {
+		_, err := tool.Execute(context.Background(), []byte(`{"path":"new.txt","content":"hello world"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data, readErr := os.ReadFile("new.txt")
+		if readErr != nil {
+			t.Fatalf("expected file to exist: %v", readErr)
+		}
+		if string(data) != "hello world" {
+			t.Errorf("expected file contents %q, got %q", "hello world", string(data))
+		}
+	})
+
+	t.Run("overwrites an existing file", func(t *testing.T) {
+		if err := os.WriteFile("existing.txt", []byte("old content"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := tool.Execute(context.Background(), []byte(`{"path":"existing.txt","content":"new content"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data, readErr := os.ReadFile("existing.txt")
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(data) != "new content" {
+			t.Errorf("expected file contents %q, got %q", "new content", string(data))
+		}
+	})
+
+	t.Run("rejects a path outside the working directory", func(t *testing.T) {
+		_, err := tool.Execute(context.Background(), []byte(`{"path":"../../../etc/passwd","content":"x"}`))
+		if err == nil {
+			t.Error("expected an error for a path outside the working directory")
+		}
+	})
+
+	t.Run("supports a nested new directory-free path", func(t *testing.T) {
+		dir := t.TempDir()
+		chdirForTest(t, dir)
+		_, err := tool.Execute(context.Background(), []byte(`{"path":"nested.txt","content":"x"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "nested.txt")); statErr != nil {
+			t.Errorf("expected file to exist: %v", statErr)
+		}
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -266,3 +266,29 @@ func LoadDocument() (string, error) {
 
 	return document, nil
 }
+
+// maxGitBoundaryWalkLevels bounds FindGitBoundary's upward search as a
+// defensive cap against a pathologically deep dir with no repo above it.
+const maxGitBoundaryWalkLevels = 64
+
+// FindGitBoundary walks upward from dir looking for the first ancestor
+// (inclusive) containing a .git entry, capped at maxGitBoundaryWalkLevels.
+// Returns "" if none is found. Shared by the project-context discovery
+// feature and the tool-use permission engine's per-repository approval
+// scoping - both need identical repo-root-detection behavior.
+func FindGitBoundary(dir string) string {
+	current := dir
+	for i := 0; i < maxGitBoundaryWalkLevels; i++ {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			// reached filesystem root
+			return ""
+		}
+		current = parent
+	}
+	return ""
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,11 +67,12 @@ func ProcessStreamingOutput(output *bedrockruntime.ConverseStreamOutput, handler
 	return msg, nil
 }
 
-// ValidateLocalPath confines filename resolution to the current working
-// directory, returning the validated absolute path or an error if filename
-// escapes it or doesn't exist. Used by the read_file tool so the model
-// cannot read arbitrary paths on the host.
-func ValidateLocalPath(filename string) (string, error) {
+// confineToWorkingDir resolves filename against the current working
+// directory and returns the resulting absolute path, or an error if
+// filename would escape it. Shared by ValidateLocalPath (which additionally
+// requires the file to exist) and ValidateLocalPathForWrite (which doesn't,
+// since a write may create a new file).
+func confineToWorkingDir(filename string) (string, error) {
 	baseDir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("unable to get working directory: %w", err)
@@ -87,12 +88,33 @@ func ValidateLocalPath(filename string) (string, error) {
 		return "", fmt.Errorf("access denied: %s is outside of the allowed directory", filename)
 	}
 
+	return fullPath, nil
+}
+
+// ValidateLocalPath confines filename resolution to the current working
+// directory, returning the validated absolute path or an error if filename
+// escapes it or doesn't exist. Used by the read_file tool so the model
+// cannot read arbitrary paths on the host.
+func ValidateLocalPath(filename string) (string, error) {
+	fullPath, err := confineToWorkingDir(filename)
+	if err != nil {
+		return "", err
+	}
+
 	// Check if the file exists
 	if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
 		return "", fmt.Errorf("file does not exist: %s", filename)
 	}
 
 	return fullPath, nil
+}
+
+// ValidateLocalPathForWrite confines filename resolution to the current
+// working directory like ValidateLocalPath, but does not require the file
+// to already exist - used by the write_file tool, which may create a new
+// file or overwrite an existing one.
+func ValidateLocalPathForWrite(filename string) (string, error) {
+	return confineToWorkingDir(filename)
 }
 
 // resolveUserPath resolves a user-supplied path for --document and --image.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -430,3 +430,43 @@ func TestStringPrompt(t *testing.T) {
 	// we'll leave this as an integration test candidate
 	t.Skip("StringPrompt requires stdin interaction - should be tested in integration tests")
 }
+
+func TestFindGitBoundary(t *testing.T) {
+	t.Run("matches at dir's own .git", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0750); err != nil {
+			t.Fatalf("failed to create .git dir: %v", err)
+		}
+
+		if got := FindGitBoundary(root); got != root {
+			t.Errorf("expected %s, got %s", root, got)
+		}
+	})
+
+	t.Run("matches at a nested parent's .git", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, ".git"), 0750); err != nil {
+			t.Fatalf("failed to create .git dir: %v", err)
+		}
+		sub := filepath.Join(root, "a", "b", "c")
+		if err := os.MkdirAll(sub, 0750); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+
+		if got := FindGitBoundary(sub); got != root {
+			t.Errorf("expected %s, got %s", root, got)
+		}
+	})
+
+	t.Run("no .git anywhere returns empty string", func(t *testing.T) {
+		root := t.TempDir()
+		sub := filepath.Join(root, "a", "b")
+		if err := os.MkdirAll(sub, 0750); err != nil {
+			t.Fatalf("failed to create nested dir: %v", err)
+		}
+
+		if got := FindGitBoundary(sub); got != "" {
+			t.Errorf("expected empty string, got %s", got)
+		}
+	})
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -354,6 +354,39 @@ func TestValidateLocalPath(t *testing.T) {
 	}
 }
 
+func TestValidateLocalPathForWrite(t *testing.T) {
+	tempDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Errorf("Failed to change back to original directory: %v", err)
+		}
+	}()
+
+	t.Run("a path to a file that does not exist yet succeeds", func(t *testing.T) {
+		fullPath, err := ValidateLocalPathForWrite("new-file.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fullPath == "" {
+			t.Error("expected a non-empty validated path")
+		}
+	})
+
+	t.Run("path traversal attempt is still rejected", func(t *testing.T) {
+		if _, err := ValidateLocalPathForWrite("../../../etc/passwd"); err == nil {
+			t.Error("expected an error for a path outside the working directory")
+		}
+	})
+}
+
 func TestResolveUserPath(t *testing.T) {
 	tempDir := t.TempDir()
 	docPath := filepath.Join(tempDir, "doc.pdf")


### PR DESCRIPTION
## Summary

Closes #86 — the second item from the "agentic direction" idea group (#86-#88), following #97 (Bedrock capability catch-up) and #102 (AGENTS.md discovery). `chat` gains 3 new tools and a real permission system, going meaningfully beyond the issue's original text based on follow-up discussion:

- **3 new built-in tools**: `write_file` (create/overwrite, cwd-confined), `run_shell` (arbitrary shell command, 30s timeout, 32KB truncated output), `git_diff` (read-only, optional path/ref argument)
- **Automatic tool-use enablement** — the `--tools` flag is gone entirely. `chat` always attempts tool use; if a model/request rejects it, one automatic retry without tools kicks in (mirroring #83's cache-point retry pattern), with a visible notice, so a non-tool-capable model never breaks the session
- **Confirmation gate for destructive actions** — `write_file`/`run_shell` block for a decision before executing; `read_file`/`git_diff` stay silent since they're read-only. Three choices at the prompt: approve **once**, **this session**, or **always** (persisted, scoped per git repository — an approval in one project never applies to another)
- **Coarse sticky-approval patterns** — `run_shell` approvals key off the base command (e.g. approving one `git diff` offers to approve all `git *`); `write_file` approvals key off the containing directory

### Notable implementation details
- Extends Unit 2's `Tool` interface (`#82`) with `RequiresConfirmation()`/`ConfirmationSummary()` rather than a separate registry-side lookup — `Registry.Dispatch` consults a new `PermissionGate` before executing any tool that requires it.
- New `ApprovalStore` (session tier in-memory, "always" tier persisted at `<ConfigPath>/tool-approvals.yaml`, `0600` perms) needed the same repo-root detection #88 already built. Extracted `utils.FindGitBoundary` from #88's private `findGitBoundary` rather than duplicating it — the one change to already-shipped code in this PR, verified against #88's own existing test suite as a regression net.
- **Found and fixed two real bugs during implementation, not just design-time assumptions**:
  - `utils.ValidateLocalPath` requires the target file to already exist — wrong for `write_file`'s create-new-file case. Fixed additively with a new `ValidateLocalPathForWrite` sharing a private confinement helper, zero regression risk to already-shipped callers.
  - `RunShellTool`'s timeout didn't actually bound wall-clock time for commands with grandchild processes (`sh -c "sleep 5"` — killing only `sh` left `sleep` running, holding the output pipe open). Fixed by running commands in their own process group and killing the whole group on timeout; caught via a "test passes but takes 5s instead of ~50ms" signal, and the test now asserts prompt return time so the regression class can't silently return.
- A non-zero exit code from `run_shell` is reported in the tool's output text (`[exit code: N]`), not as a Go error — the model sees a failed command as normal operation, not a tool bug.
- **`isToolUseUnsupportedError`'s request shape is a best-effort heuristic**, unverified against real Bedrock error text — same risk category as #97's `reasoning_config` shape. Flagged in the verification list below.

### Process
Built using AI-DLC (requirements → user stories → workflow planning → application design → units generation → 3 units, each with functional design/NFR/code generation → build and test). This is the most complete Inception/Construction treatment of any initiative in this series so far, proportional to the risk of adding arbitrary shell execution and destructive file writes. Full audit trail and design artifacts are under `aidlc-docs/`.

## Test plan

- [x] `make test` — all packages pass, no regressions (coverage 67.8% → 70.9% total across the initiative)
- [x] `make lint` — clean
- [x] `go test -tags=integration -v .` — all 7 integration tests pass, including confirmation that `--tools` is fully gone
- [x] Cross-unit composition scenarios: `--system`+`--thinking`+always-on-tools combined; #88's `--no-context-file` + always-on tools combined — both reach the AWS-credentials boundary cleanly with no panics
- [x] Confirmation gate verified end-to-end via real components (no AWS needed): approve-once creates the file, deny blocks it cleanly with the model getting an error result, a session approval correctly skips re-prompting for a matching `run_shell` call, and `git_diff` never touches the gate at all
- [x] Per-repository "always"-approval isolation verified at the unit level (an approval in one repo never leaks into another)
- [ ] **Not yet verified — needs real AWS credentials**: an actual tool-call round-trip against live Bedrock for the 3 new tools, and whether `isToolUseUnsupportedError`'s heuristic actually matches real Bedrock rejection text. See `aidlc-docs/construction/build-and-test/builtin-tools-summary.md` for the full, risk-ranked list (carries forward #97's still-open `reasoning_config` verification item too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hxx6CHPFfwPpgF8uX7a9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hxx6CHPFfwPpgF8uX7a9Q)_