### PR TITLE
Extract platform-specific process group handling into separate files

### DIFF
--- a/tools/runshell.go
+++ b/tools/runshell.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
@@ -83,7 +82,7 @@ func (t *RunShellTool) Execute(ctx context.Context, input json.RawMessage) (stri
 	// shell itself - killing only the shell leaves such children running
 	// and holding the output pipe open, which would otherwise block
 	// CombinedOutput() below well past the intended timeout.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 
 	type result struct {
 		output []byte
@@ -97,9 +96,7 @@ func (t *RunShellTool) Execute(ctx context.Context, input json.RawMessage) (stri
 
 	select {
 	case <-runCtx.Done():
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		}
+		killProcessGroup(cmd)
 		<-done // wait for the goroutine to unblock now that the group is dead
 		return "", fmt.Errorf("command timed out after %s", timeout)
 

--- a/tools/runshell_unix.go
+++ b/tools/runshell_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package tools
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts cmd in its own process group so killProcessGroup can
+// terminate it along with any children (e.g. a grandchild like `sleep`
+// spawned by `sh -c`) rather than just the shell itself.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup kills the process group started by setProcessGroup.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/tools/runshell_windows.go
+++ b/tools/runshell_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package tools
+
+import "os/exec"
+
+// setProcessGroup is a no-op on Windows; process groups are set up
+// differently there and aren't needed for this tool's use case.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup kills the process directly, since Unix-style process
+// groups aren't available on Windows.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}


### PR DESCRIPTION
## Summary
Refactored platform-specific process group management in the RunShell tool by extracting Unix and Windows implementations into separate build-tagged files. This improves code organization and maintainability while preserving existing functionality.

## Key Changes
- Created `tools/runshell_unix.go` with Unix-specific process group handling:
  - `setProcessGroup()` uses `syscall.SysProcAttr` with `Setpgid: true` to isolate process groups
  - `killProcessGroup()` uses `syscall.Kill()` with negative PID to terminate entire process group and children
  
- Created `tools/runshell_windows.go` with Windows-specific implementations:
  - `setProcessGroup()` is a no-op since Windows doesn't use Unix-style process groups
  - `killProcessGroup()` directly kills the process using `Process.Kill()`

- Updated `tools/runshell.go`:
  - Removed `syscall` import (now platform-specific)
  - Replaced inline `syscall.SysProcAttr` assignment with `setProcessGroup(cmd)` call
  - Replaced inline `syscall.Kill()` call with `killProcessGroup(cmd)` call

## Implementation Details
- Both files use Go build tags (`//go:build !windows` and `//go:build windows`) to ensure correct compilation per platform
- The refactoring maintains the original behavior: preventing zombie child processes when shell commands timeout by killing entire process groups on Unix and individual processes on Windows
- No functional changes to the timeout handling logic in `runshell.go`

https://claude.ai/code/session_01W8jHzrLsvfPEop9qWU5t48