### PR TITLE
Migrate legacy sqlite3 driver to modernc.org/sqlite

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,25 @@ func (fm *FileManager) InitializeViper() error {
 		return err
 	}
 
-	return viper.ReadInConfig()
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	return fm.migrateLegacyDBDriver()
+}
+
+// migrateLegacyDBDriver rewrites config files persisted by chat-cli
+// versions before v0.5.3, which wrote db_driver: sqlite3 (the name of the
+// old CGO mattn/go-sqlite3 driver). That driver was replaced by the
+// pure-Go modernc.org/sqlite driver under the identifier "sqlite", so an
+// un-migrated config makes factory.CreateDatabase fail with "unsupported
+// database driver: sqlite3" after upgrading.
+func (fm *FileManager) migrateLegacyDBDriver() error {
+	if viper.GetString("db_driver") != "sqlite3" {
+		return nil
+	}
+	viper.Set("db_driver", "sqlite")
+	return viper.WriteConfig()
 }
 
 // GetDBPath returns the full path to the SQLite database file

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -325,6 +326,54 @@ func TestInitializeViper(t *testing.T) {
 	configPath := filepath.Join(fm.ConfigPath, fm.ConfigFile)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Errorf("config file was not created: %s", configPath)
+	}
+
+	viper.Reset()
+}
+
+// TestInitializeViper_MigratesLegacySqlite3Driver covers configs written by
+// chat-cli versions before v0.5.3, which persisted db_driver: sqlite3 (the
+// name of the old CGO mattn/go-sqlite3 driver). Since that driver was
+// replaced by the pure-Go modernc.org/sqlite driver under the identifier
+// "sqlite", an un-migrated config makes factory.CreateDatabase fail with
+// "unsupported database driver: sqlite3" on every upgrade.
+func TestInitializeViper_MigratesLegacySqlite3Driver(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Simulate a config file written by a pre-v0.5.3 install.
+	legacyConfig := "db_driver: sqlite3\nenvironment: testing\n"
+	configPath := filepath.Join(tempDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(legacyConfig), 0600); err != nil {
+		t.Fatalf("failed to write legacy config: %v", err)
+	}
+
+	fm := &FileManager{
+		AppName:     "test-app",
+		ConfigFile:  "config.yaml",
+		DBFile:      "data.db",
+		Environment: "testing",
+		ConfigPath:  tempDir,
+		DataPath:    tempDir,
+	}
+
+	viper.Reset()
+
+	if err := fm.InitializeViper(); err != nil {
+		t.Fatalf("InitializeViper failed: %v", err)
+	}
+
+	if driver := fm.GetDBDriver(); driver != "sqlite" {
+		t.Errorf("expected legacy %q driver to be migrated to %q, got %q", "sqlite3", "sqlite", driver)
+	}
+
+	// The file on disk should be rewritten too, so the fix is permanent
+	// rather than needing to migrate in memory on every run.
+	rewritten, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file back: %v", err)
+	}
+	if strings.Contains(string(rewritten), "sqlite3") {
+		t.Errorf("expected config file to no longer contain %q, got: %s", "sqlite3", rewritten)
 	}
 
 	viper.Reset()


### PR DESCRIPTION
## Summary
Adds automatic migration of legacy database driver configuration from `sqlite3` (the old CGO-based mattn/go-sqlite3 driver) to `sqlite` (the pure-Go modernc.org/sqlite driver). This ensures that configurations created by chat-cli versions before v0.5.3 continue to work after upgrading without manual intervention.

## Key Changes
- **Added `migrateLegacyDBDriver()` method** in `config/config.go` that:
  - Detects when `db_driver` is set to the legacy `sqlite3` value
  - Automatically rewrites it to `sqlite`
  - Persists the change to disk via `viper.WriteConfig()` so the migration is permanent
  - Returns early if no migration is needed

- **Updated `InitializeViper()` method** to call the migration function after loading the config file, ensuring the fix is applied transparently during startup

- **Added comprehensive test** `TestInitializeViper_MigratesLegacySqlite3Driver` in `config/config_test.go` that:
  - Simulates a legacy config file with `db_driver: sqlite3`
  - Verifies the in-memory config is migrated to `sqlite`
  - Confirms the config file on disk is rewritten to prevent repeated migrations

## Implementation Details
The migration is transparent to users—it happens automatically during config initialization without requiring any manual steps. The config file is rewritten to disk to ensure the fix is permanent and doesn't need to be applied on every startup.

https://claude.ai/code/session_01W8jHzrLsvfPEop9qWU5t48