### PR TITLE
Fix fatal crash when tool-input JSON is truncated

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -303,5 +303,5 @@ func init() {
 
 	promptCmd.PersistentFlags().Float32("temperature", 1.0, "optional temperature (0-1); omitted from the request unless set")
 	promptCmd.PersistentFlags().Float32("topP", 0.999, "optional top-P (0-1); omitted from the request unless set")
-	promptCmd.PersistentFlags().Int32("max-tokens", 500, "max tokens")
+	promptCmd.PersistentFlags().Int32("max-tokens", 4096, "max tokens")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,5 +56,5 @@ func init() {
 	rootCmd.PersistentFlags().String("thinking-effort", defaultThinkingEffort, "reasoning effort for adaptive models: low, medium, or high (requires --thinking)")
 	rootCmd.PersistentFlags().Float32("temperature", 1.0, "optional temperature (0-1); omitted from the request unless set")
 	rootCmd.PersistentFlags().Float32("topP", 0.999, "optional top-P (0-1); omitted from the request unless set")
-	rootCmd.PersistentFlags().Int32("max-tokens", 500, "max tokens")
+	rootCmd.PersistentFlags().Int32("max-tokens", 4096, "max tokens")
 }

--- a/cmd/toolloop.go
+++ b/cmd/toolloop.go
@@ -135,10 +135,7 @@ func accumulateStream(events <-chan types.ConverseStreamOutput, onText, onReason
 				Value: &types.ReasoningContentBlockMemberReasoningText{Value: reasoningTextBlock},
 			})
 		case blockKindToolUse:
-			call, err := finalizeToolCall(acc.toolName, acc.toolUseID, acc.toolInput.String())
-			if err != nil {
-				return types.Message{}, nil, "", err
-			}
+			call := finalizeToolCall(acc.toolName, acc.toolUseID, acc.toolInput.String())
 			toolCalls = append(toolCalls, call)
 
 			content = append(content, &types.ContentBlockMemberToolUse{
@@ -203,7 +200,12 @@ func runChatTurnWithTools(
 
 		var resultContent []types.ContentBlock
 		for _, call := range toolCalls {
-			result := registry.Dispatch(ctx, call, gate)
+			var result types.ToolResultBlock
+			if call.InputParseErr != nil {
+				result = toolParseErrorResult(call.ToolUseID, call.InputParseErr)
+			} else {
+				result = registry.Dispatch(ctx, call, gate)
+			}
 			resultContent = append(resultContent, &types.ContentBlockMemberToolResult{Value: result})
 		}
 		input.Messages = append(input.Messages, types.Message{
@@ -214,22 +216,40 @@ func runChatTurnWithTools(
 }
 
 // finalizeToolCall parses a tool call's accumulated raw JSON input fragments
-// into a tools.ToolCall, validating the JSON is well-formed (Rule 4 in
-// functional-design/business-rules.md) before it's ever dispatched.
-func finalizeToolCall(name, toolUseID, rawInput string) (tools.ToolCall, error) {
+// into a tools.ToolCall. Malformed or truncated JSON (common when max-tokens
+// cuts off a large write_file payload mid-stream) sets InputParseErr so the
+// caller can return an error result to the model instead of aborting chat.
+func finalizeToolCall(name, toolUseID, rawInput string) tools.ToolCall {
+	call := tools.ToolCall{
+		Name:      name,
+		ToolUseID: toolUseID,
+	}
+
 	if rawInput == "" {
 		rawInput = "{}"
 	}
 
 	if !json.Valid([]byte(rawInput)) {
-		return tools.ToolCall{}, fmt.Errorf("invalid tool input for %s: not valid JSON", name)
+		call.Input = json.RawMessage("{}")
+		call.InputParseErr = fmt.Errorf(
+			"invalid tool input for %s: not valid JSON (response may have been truncated by max-tokens; retry with smaller content)",
+			name,
+		)
+		return call
 	}
 
-	return tools.ToolCall{
-		Name:      name,
-		ToolUseID: toolUseID,
-		Input:     json.RawMessage(rawInput),
-	}, nil
+	call.Input = json.RawMessage(rawInput)
+	return call
+}
+
+func toolParseErrorResult(toolUseID string, err error) types.ToolResultBlock {
+	return types.ToolResultBlock{
+		ToolUseId: aws.String(toolUseID),
+		Status:    types.ToolResultStatusError,
+		Content: []types.ToolResultContentBlock{
+			&types.ToolResultContentBlockMemberText{Value: err.Error()},
+		},
+	}
 }
 
 // toolInputDocument converts validated tool-call JSON into the document

--- a/cmd/toolloop_test.go
+++ b/cmd/toolloop_test.go
@@ -4,15 +4,102 @@ Copyright © 2024 Micah Walter
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/chat-cli/chat-cli/tools"
 )
+
+func malformedWriteFileChannel(toolUseID string) <-chan types.ConverseStreamOutput {
+	ch := make(chan types.ConverseStreamOutput, 5)
+	ch <- &types.ConverseStreamOutputMemberContentBlockStart{
+		Value: types.ContentBlockStartEvent{
+			ContentBlockIndex: aws.Int32(0),
+			Start: &types.ContentBlockStartMemberToolUse{
+				Value: types.ToolUseBlockStart{Name: aws.String("write_file"), ToolUseId: aws.String(toolUseID)},
+			},
+		},
+	}
+	// Truncated JSON, as happens when max-tokens cuts off mid tool-input stream.
+	ch <- &types.ConverseStreamOutputMemberContentBlockDelta{
+		Value: types.ContentBlockDeltaEvent{
+			ContentBlockIndex: aws.Int32(0),
+			Delta: &types.ContentBlockDeltaMemberToolUse{
+				Value: types.ToolUseBlockDelta{Input: aws.String(`{"path":"hello.py","content":"def main(`)},
+			},
+		},
+	}
+	ch <- &types.ConverseStreamOutputMemberMessageStop{
+		Value: types.MessageStopEvent{StopReason: types.StopReasonToolUse},
+	}
+	close(ch)
+	return ch
+}
+
+func TestAccumulateStream_MalformedToolInputDoesNotError(t *testing.T) {
+	_, toolCalls, stopReason, err := accumulateStream(
+		malformedWriteFileChannel("write-1"),
+		func(context.Context, string) error { return nil },
+		func(context.Context, string) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("expected malformed tool JSON to be recoverable, got error: %v", err)
+	}
+	if stopReason != types.StopReasonToolUse {
+		t.Fatalf("expected tool_use stop reason, got %v", stopReason)
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCalls))
+	}
+	if toolCalls[0].InputParseErr == nil {
+		t.Fatal("expected InputParseErr to be set for truncated JSON")
+	}
+}
+
+func TestRunChatTurnWithTools_MalformedToolInputRecovers(t *testing.T) {
+	callCount := 0
+	send := func(_ context.Context, _ *bedrockruntime.ConverseStreamInput) (<-chan types.ConverseStreamOutput, error) {
+		callCount++
+		if callCount == 1 {
+			return malformedWriteFileChannel("write-1"), nil
+		}
+		return textOnlyChannel("recovered after tool input error"), nil
+	}
+
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool())
+	input := &bedrockruntime.ConverseStreamInput{}
+
+	result, err := runChatTurnWithTools(
+		context.Background(),
+		send,
+		input,
+		registry,
+		nil,
+		func(context.Context, string) error { return nil },
+		func(context.Context, string) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("expected recovery from malformed tool input, got: %v", err)
+	}
+	if !strings.Contains(result, "recovered after tool input error") {
+		t.Fatalf("expected model to continue after tool error, got %q", result)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 round trips (error result + retry), got %d", callCount)
+	}
+}
 
 func TestFinalizeToolCall(t *testing.T) {
 	t.Run("valid JSON input", func(t *testing.T) {
-		call, err := finalizeToolCall("read_file", "tool-use-1", `{"path":"go.mod"}`)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		call := finalizeToolCall("read_file", "tool-use-1", `{"path":"go.mod"}`)
+		if call.InputParseErr != nil {
+			t.Fatalf("unexpected parse error: %v", call.InputParseErr)
 		}
 		if call.Name != "read_file" {
 			t.Errorf("expected name 'read_file', got %q", call.Name)
@@ -25,17 +112,17 @@ func TestFinalizeToolCall(t *testing.T) {
 		}
 	})
 
-	t.Run("malformed JSON input", func(t *testing.T) {
-		_, err := finalizeToolCall("read_file", "tool-use-2", `{"path": not valid`)
-		if err == nil {
-			t.Error("expected an error for malformed JSON, got none")
+	t.Run("malformed JSON input sets parse error", func(t *testing.T) {
+		call := finalizeToolCall("read_file", "tool-use-2", `{"path": not valid`)
+		if call.InputParseErr == nil {
+			t.Error("expected InputParseErr for malformed JSON, got none")
 		}
 	})
 
 	t.Run("empty input treated as empty object", func(t *testing.T) {
-		call, err := finalizeToolCall("read_file", "tool-use-3", "")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		call := finalizeToolCall("read_file", "tool-use-3", "")
+		if call.InputParseErr != nil {
+			t.Fatalf("unexpected parse error: %v", call.InputParseErr)
 		}
 		if string(call.Input) != "{}" {
 			t.Errorf("expected empty input to become '{}', got %q", string(call.Input))
@@ -57,4 +144,14 @@ func TestToolInputDocument(t *testing.T) {
 			t.Fatal("expected non-nil document")
 		}
 	})
+}
+
+func TestFinalizeToolCall_TruncatedJSONSetsParseErr(t *testing.T) {
+	call := finalizeToolCall("write_file", "id-1", `{"path":"a.py","content":"unfinished`)
+	if call.InputParseErr == nil {
+		t.Fatal("expected InputParseErr for truncated JSON")
+	}
+	if string(call.Input) != "{}" {
+		t.Fatalf("expected placeholder input {}, got %s", call.Input)
+	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -112,7 +112,7 @@ Use `--thinking` on a model that supports extended thinking / reasoning mode to 
 chat-cli prompt "What's 17 * 24?" --thinking
 ```
 
-Reasoning is printed dimmed and prefixed with `[thinking]`, separate from the final answer. Extended thinking needs a token budget, controlled by `--thinking-budget` (default `1024`) — this budget must fit within `--max-tokens` (default `500`), so you'll likely need to raise `--max-tokens` when using `--thinking`. `--thinking` has no effect unless explicitly set (behavior is unchanged by default).
+Reasoning is printed dimmed and prefixed with `[thinking]`, separate from the final answer. Extended thinking needs a token budget, controlled by `--thinking-budget` (default `1024`) — this budget must fit within `--max-tokens` (default `4096`). `--thinking` has no effect unless explicitly set (behavior is unchanged by default).
 
 > **Note**: the exact request format for enabling extended thinking varies by model provider and isn't part of Bedrock's typed API — if `--thinking` doesn't work for a given model, that's the most likely reason.
 

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -15,6 +15,11 @@ type ToolCall struct {
 	Name      string
 	ToolUseID string
 	Input     json.RawMessage
+	// InputParseErr is set when the model's streamed tool-input JSON was
+	// malformed or truncated (e.g. max-tokens cut off mid-stream). Dispatch
+	// must not call Execute in that case; return this error to the model
+	// instead so it can retry.
+	InputParseErr error
 }
 
 // Registry holds the set of tools available to a chat session and mediates


### PR DESCRIPTION
## Summary

Closes #111

- Raise default `--max-tokens` from 500 to 4096 so agentic tool calls (especially `write_file` with multi-line content) are not cut off mid-JSON
- Recover gracefully when streamed tool-input JSON is malformed/truncated: return an error tool result to the model instead of `log.Fatal`, allowing the session to continue

## Test plan

- [x] `TMPDIR=/tmp GOPROXY=direct make test-short` — all packages pass
- [x] New tests for truncated `write_file` JSON recovery (`TestAccumulateStream_MalformedToolInputDoesNotError`, `TestRunChatTurnWithTools_MalformedToolInputRecovers`)
- [x] Existing `TestFinalizeToolCall` / `TestToolInputDocument` updated for new behavior


Made with [Cursor](https://cursor.com)